### PR TITLE
Renaming terminology and exported identifiers

### DIFF
--- a/custom-macro-transformers.scm
+++ b/custom-macro-transformers.scm
@@ -2,7 +2,7 @@
   (custom-macro-transformers
    (import (scheme base)))
   (else
-   (import (except (scheme base)
+   (import (except (scheme base) 
 		   define-syntax
 		   let-syntax
 		   letrec-syntax

--- a/srfi-148.html
+++ b/srfi-148.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>SRFI 148: Composable macros</title>
+    <title>SRFI 148: Eager syntax-rules</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="/srfi.css" type="text/css" />
   </head>
@@ -11,7 +11,7 @@
 
 <h1>Title</h1>
 
-Composable macros    
+Eager <code>syntax-rules</code>
 
 <h1>Author</h1>
 
@@ -31,47 +31,14 @@ Marc Nieper-Wi&szlig;kirchen
 Writing powerful <code>syntax-rules</code> macros is hard because they
 do not compose well: The arguments of a macro expansion are not
 expanded.  This SRFI defines an easy to comprehend high-level system
-for writing powerful, composable macros, one of whose defining features is that
-it can be portably implemented in any Scheme implementation conforming
-to the R7RS.
+for writing powerful, composable (or <em>eager</em>) macros, two of whose defining
+features are that its macro arguments are (in general) eagerly expanded and that it can
+be portably implemented in any Scheme implementation conforming to the
+R7RS.
 
 <h1>Issues</h1>
 
-<ul>
-<li><p>
-  Are there any essential ck-macros that should be added to this specification?
-  </p>
-</li>
-<li
-   ><p> Should we try hard and allow circular/dotted lists as
-    arguments to the pre-defined ck-macros where viable?
-  </p>
-</li>
-<li>
-  <p>
-  Should the references to the CK-machine be omitted in the
-  terminology of this SRFI?  For example, should we
-  rename <em>ck-macro</em> to composable macro throughout? In this
-  case: what would be a good prefix instead of <code>ck-</code> for
-  the predefined composable macros?
-  </p>
-</li>
-<li>
-  <p>Should the name of the essential macro <code>ck-expression</code>
-  be shortened, <i>e.g.</i> to a name consisting of an otherwise unused
-  character?
-  </p>
-</li>
-<li>
-  <p>Currently, this specification defines no way to define anonymous
-    macros (<em>i.e.</em> the equivalent to <code>lambda</code>).
-    Should this SRFI
-    define such a thing?  And, if this is the case, what
-    should be the exact semantics that work well with the idea of
-    lexical scoping and how pattern matching in Scheme macros work?
-  </p>
-</li>
-</ul>
+All previous issues have been resolved.
 
 <h1>Rationale</h1>
 
@@ -98,21 +65,21 @@ to the R7RS.
   systems (or building on run-time evaluation when expansion at
   compile time would be beneficial to running time), this SRFI
   defines a custom macro transformer
-  <code>ck-macro-transformer</code>, which allows one to write composable
+  <code>em-syntax-rules</code>, which allows one to write eager
   macros, while retaining the hygiene and beauty of <code>syntax-rules</code>.
-  This high-level system of composable macros is based on the idea of
-  CK-macros, which has
+  This high-level system of eager macros is based on the idea of
+  eager macros, which has
   been <a href="http://okmij.org/ftp/Scheme/macros.html#ck-macros">popularized
   by Oleg Kiselyov</a>.
 </p>
 
 <p>
   There are at least three arguments in favor of standardizing a
-  system of composable macros based on <code>syntax-rules</code>.
+  system of eager macros based on <code>syntax-rules</code>.
   Firstly, some standardization makes it simpler to understand and
   share each other's (macro) code.  Secondly, by standardizing this
   system, future additions to the standard in the form of primitive
-  ck-macros (<em>e.g.</em> a ck-macro keyword <code>ck-number?</code>
+  eager macros (<em>e.g.</em> an eager macro keyword <code>em-number?</code>
   that can discern whether some syntax is a number literal or not) are
   made possible, and can be used to improve the expressiveness
   of <code>syntax-rules</code> while retaining hygiene.  Thirdly, it
@@ -126,7 +93,7 @@ to the R7RS.
 <p>
 One should get a good feeling about how the macro facility presented
 in this SRFI is to be used by studying the implementations of the
-various predefined composable macros (see below), which are contained
+various predefined eager macros (see below), which are contained
 in a <a href="srfi/148.macros.scm">file of the sample implementation</a>.
 </p>
 
@@ -140,19 +107,19 @@ in a <a href="srfi/148.macros.scm">file of the sample implementation</a>.
 </p>
 
 <pre>
- (ck-expression (ck-list-&gt;vector (ck-fact '(1 2 3))))
+ (em (em-list-&gt;vector (em-fact '(1 2 3))))
 </pre>
 
 <h2>The <code>letrec</code>-binding construct</h2>
 
 <p>The definition of <code>letrec</code> as given in the appendix 7.3
-  of the R7RS can be rewritten as a composable macro as follows:</p>
+  of the R7RS can be rewritten as an eager macro as follows:</p>
 
 <pre>
  (define-syntax letrec
-   (ck-macro-transformer ()
+   (em-syntax-rules ()
      ((letrec ((var1 init1) ...) body ...)
-      ((ck-generate-temporaries '(var1 ...)) =&gt; '(temp1 ...))
+      ((em-generate-temporaries '(var1 ...)) =&gt; '(temp1 ...))
       '(let ((var1 &lt;undefined&gt;) ...)
         (let ((temp1 init1) ...)
             (set! var1 temp1)
@@ -163,11 +130,11 @@ in a <a href="srfi/148.macros.scm">file of the sample implementation</a>.
 <h2>The <code>do</code>-iteration construct</h2>
 
 <p>The definition of <code>do</code> as given in the appendix 7.3
-  of the R7RS can be rewritten as a composable macro as follows without "using a trick":</p>
+  of the R7RS can be rewritten as an eager macro as follows without "using a trick":</p>
 
 <pre>
  (define-syntax do
-   (ck-macro-transformer ()
+   (em-syntax-rules ()
      ((do ((var init . step*) ...)
           (test expr ...)
         command ...)
@@ -180,9 +147,9 @@ in a <a href="srfi/148.macros.scm">file of the sample implementation</a>.
                 (begin
                   command
                   ...
-                  (loop ,(ck-if (ck-null? 'step*)
+                  (loop ,(em-if (em-null? 'step*)
                                 'var
-                                (ck-car 'step*)) 
+                                (em-car 'step*)) 
                         ...))))))
          (loop init ...)))))
 </pre>
@@ -202,9 +169,9 @@ in a <a href="srfi/148.macros.scm">file of the sample implementation</a>.
            (srfi 148))
    (begin
      (define-syntax simple-match
-       (ck-macro-transformer ()
+       (em-syntax-rules ()
 	 ((simple-match expr (pattern . body) ...)
-	  (ck-expression
+	  (em
 	   `(call-with-current-continuation
 	     (lambda (return)
 	       (let ((e expr))
@@ -215,7 +182,7 @@ in a <a href="srfi/148.macros.scm">file of the sample implementation</a>.
 		     (error "does not match" expr)))))))))
 
      (define-syntax compile-pattern
-       (ck-macro-transformer ()
+       (em-syntax-rules ()
 	 ((compile-pattern '() 'e)
 	  '(((null? e))))
 	 ((compile-pattern '(pattern1 pattern2 ...) 'e)
@@ -225,7 +192,7 @@ in a <a href="srfi/148.macros.scm">file of the sample implementation</a>.
 	    ,@(compile-pattern 'pattern1 'e1)
 	    ,@(compile-pattern '(pattern2 ...) 'e2)))
 	 ((compile-pattern 'x 'e)
-	  (ck-if (ck-symbol? 'x)
+	  (em-if (em-symbol? 'x)
 	    '((x e))
 	    '(((equal? x e)))))))))
 </pre>
@@ -252,23 +219,23 @@ in a <a href="srfi/148.macros.scm">file of the sample implementation</a>.
 <h2>Overview</h2>
 
 <p>
-A composable macro is a (hygienic) macro whose keyword is bound to a
+An eager macro is a (hygienic) macro whose keyword is bound to a
 transformer specified by an instance
-of <code>ck-macro-transformer</code> instead of an instance
+of <code>em-syntax-rules</code> instead of an instance
 of <code>syntax-rules</code>.  A transformer spec
-using <code>ck-macro-transformer</code> is very similar to the
+using <code>em-syntax-rules</code> is very similar to the
 well-known <code>syntax-rules</code>, namely of one of the two forms:
 </p>
 
 <pre>
- (ck-macro-transformer (&lt;literal&gt; ...) 
-   (&lt;ck-macro-rule ...&gt;))
- (ck-macro-transformer &lt;ellipsis&gt; (&lt;literal&gt; ...) 
-   (&lt;ck-macro-rule ...&gt;))
+ (em-syntax-rules (&lt;literal&gt; ...) 
+   (&lt;eager macro-rule ...&gt;))
+ (em-syntax-rules &lt;ellipsis&gt; (&lt;literal&gt; ...) 
+   (&lt;eager macro-rule ...&gt;))
 </pre>
 
 <p>
-  Each <code>&lt;ck-macro-rule&gt;</code> is also very similar to
+  Each <code>&lt;eager macro-rule&gt;</code> is also very similar to
   a <code>&lt;syntax rule&gt;</code>, namely of one of the forms:
 </p>
 
@@ -279,18 +246,18 @@ well-known <code>syntax-rules</code>, namely of one of the two forms:
 
 <p>
   When we forget about the <code>&lt;pattern binding spec&gt;</code>s
-  for a moment, the difference between a composable macro and
+  for a moment, the difference between an eager macro and
   a <code>syntax-rules</code>-macro lies in how the input elements
   corresponding to the <code>&lt;pattern&gt;</code>s above are
   expanded before a macro use is expanded: <code>syntax-rules</code>
   macros never expand their arguments before evaluation.  On the other
-  hand, <code>ck-macro-transformer</code> macros expand those input
+  hand, <code>em-syntax-rules</code> macros expand those input
   elements whose corresponding patterns are of the
-  form <code>'&lt;pattern&gt;</code>.  The output of a composable
+  form <code>'&lt;pattern&gt;</code>.  The output of an eager
   macro is handled as follows: If the template is of the
-  form <code>&lt;'template&gt;</code>, the composable macro expands
+  form <code>&lt;'template&gt;</code>, the eager macro expands
   into <code>&lt;template&gt;</code> (which the pattern variables
-  substituted); if the template is unquoted, the composable macro
+  substituted); if the template is unquoted, the eager macro
   expands into the expansion of the template.  This behavior is
   analogous to how evaluation of quoted datums is handled in the core Scheme
   language.
@@ -302,11 +269,11 @@ well-known <code>syntax-rules</code>, namely of one of the two forms:
 
 <pre>
  (letrec-syntax
-     ((foo (ck-macro-transformer ()
+     ((foo (em-syntax-rules ()
              ((foo 'a) (bar 'a))))
-      (bar (ck-macro-transformer ()
+      (bar (em-syntax-rules ()
              ((bar 'a) '(define a 42))))
-      (baz (ck-macro-transformer ()
+      (baz (em-syntax-rules ()
              ((baz ignore 'a) 'a))))
    (foo (baz (not-expanded) 'a))
    a)
@@ -322,7 +289,7 @@ well-known <code>syntax-rules</code>, namely of one of the two forms:
 </pre>
 
 <p>
-  These work as follows: Before the final template in a ck-macro use
+  These work as follows: Before the final template in an eager macro use
   is expanded, the pattern variables in <code>&lt;pattern&gt;</code>
   are bound according to the expansion
   of <code>&lt;template&gt;</code> (which may contain pattern
@@ -336,9 +303,9 @@ well-known <code>syntax-rules</code>, namely of one of the two forms:
 
 <pre>
  (letrec-syntax
-     ((foo (ck-macro-transformer ()
+     ((foo (em-syntax-rules ()
              ((foo 'x) ((bar 'x) =&gt; '(b c)) '(define x '(b (2 x) c)))))
-      (bar (ck-macro-transformer ()
+      (bar (em-syntax-rules ()
              ((bar 'x) '((1 x) (3 x))))))
    (foo 'x)
    x)
@@ -352,10 +319,10 @@ This SRFI extends 7.1 of the R7RS as follows:
 
 <pre>
  &lt;transformer spec&gt;
-   &xrarr; (ck-macro-transformer (&lt;identifier&gt; ...) &lt;ck-macro rule&gt; ...)
-   &xrarr; (ck-macro-transformer &lt;ellipsis&gt; (&lt;identifier&gt; ...) &lt;ck-macro rule&gt; ...)
+   &xrarr; (em-syntax-rules (&lt;identifier&gt; ...) &lt;eager macro rule&gt; ...)
+   &xrarr; (em-syntax-rules &lt;ellipsis&gt; (&lt;identifier&gt; ...) &lt;eager macro rule&gt; ...)
 
- &lt;ck-macro rule&gt;
+ &lt;eager macro rule&gt;
    &xrarr; (&lt;top-level pattern&gt; &lt;pattern binding spec&gt; ... &lt;top-level template&gt;)
 
  &lt;pattern binding spec&gt;
@@ -385,16 +352,16 @@ This SRFI extends 7.1 of the R7RS as follows:
    &xrarr; '&lt;template&gt;
 
  &lt;macro use&gt;
-   &xrarr; &lt;ck-macro use&gt;
+   &xrarr; &lt;eager macro use&gt;
 
- &lt;ck-macro use&gt;
-   &xrarr; (&lt;keyword&gt; &lt;ck-macro datum&gt; ...)
-   &xrarr; (ck-expression (&lt;keyword&gt; &lt;ck-macro datum&gt; ...))
+ &lt;eager macro use&gt;
+   &xrarr; (&lt;keyword&gt; &lt;eager macro datum&gt; ...)
+   &xrarr; (em (&lt;keyword&gt; &lt;eager macro datum&gt; ...))
  
- &lt;ck-macro datum&gt;
+ &lt;eager macro datum&gt;
    &xrarr; &lt;quoted datum&gt;
    &xrarr; &lt;quasiquoted datum&gt;
-   &xrarr; &lt;ck-macro use&gt;
+   &xrarr; &lt;eager macro use&gt;
    &xrarr; &lt;datum&gt;
 
  &lt;quoted datum&gt;
@@ -403,9 +370,9 @@ This SRFI extends 7.1 of the R7RS as follows:
  &lt;quasiquoted datum&gt;
    &xrarr; `&lt;datum&gt;
 
- &lt;slot or ck-macro datum&gt;
+ &lt;slot or eager macro datum&gt;
    &xrarr; &lt;&gt;
-   &xrarr; &lt;ck-macro datum&gt;
+   &xrarr; &lt;eager macro datum&gt;
 </pre>
 
 <h2>Auxiliary syntax</h2>
@@ -437,28 +404,28 @@ from <code>(scheme base)</code> and <a href="http://srfi.schemers.org/srfi-26/sr
 
 <p>
   Keywords bound to a transformer specified by an
-  instance of <code>ck-macro-transformer</code> define keywords
-  for <em>ck-macros</em>.
+  instance of <code>em-syntax-rules</code> define keywords
+  for <em>eager macros</em>.
 </p>
  
 <p>
-  Instances of a ck-macro have one of the following forms:
+  Instances of an eager macro have one of the following forms:
 </p>
 
 <pre>
-(&lt;keyword&gt; &lt;ck-macro datum&gt; ...)
+(&lt;keyword&gt; &lt;eager macro datum&gt; ...)
 </pre>
 
 <pre>
-(ck-expression (&lt;keyword&gt; &lt;ck-macro datum&gt; ...))
+(em (&lt;keyword&gt; &lt;eager macro datum&gt; ...))
 </pre>
 
-<p>Here, &lt;keyword&gt; is a keyword for a ck-macro.  The former form
+<p>Here, &lt;keyword&gt; is a keyword for an eager macro.  The former form
 has to be used in definition contexts, the latter when the macro use
 expands into an expression (see also below).</p>
 
 <p>
-The syntax and semantics of the <code>&lt;ck-macro rule&gt;</code>s
+The syntax and semantics of the <code>&lt;eager macro rule&gt;</code>s
 together with the (optional) specification
 of <code>&lt;ellipsis&gt;</code> and the <code>&lt;literal&gt;</code>s
 are as in the case of a <code>syntax-rules</code> transformer spec with
@@ -500,16 +467,16 @@ the following exceptions and additions:
   <li>
     <p>
     A quoted pattern <code>'&lt;pattern&gt;</code> matches an input
-    element if and only if the input element is a ck-macro use and the
+    element if and only if the input element is an eager macro use and the
     corresponding pattern <code>&lt;pattern&gt;</code> matches the
-    result of the expansion of the ck-macro use, or if it is a quoted
+    result of the expansion of the eager macro use, or if it is a quoted
     datum (or a self-quoting syntax element; see below) and the
     pattern <code>&lt;pattern&gt;</code> matches the expression, or if
     it is a quasiquoted datum and the
     pattern <code>&lt;pattern&gt;</code> matches the expansion of the
     quasiquoted datum (see below).  In other words, unquoted arguments
     (or unquoted elements in quasiquoted arguments) to quoted patterns that
-    are ck-macro uses are expanded before they are matched
+    are eager macro uses are expanded before they are matched
     (<em>call-by-value</em> semantics, different from
     the <em>call-by-reference</em> semantics of
     ordinary <code>syntax-rules</code>-macros).
@@ -541,7 +508,7 @@ the following exceptions and additions:
       However, unquoted template elements, that is template elements
       of the form <code>,&lt;template element&gt;</code>, inside the
       quasiquoted template are expanded first and are handled as if
-      they are an unquoted top-level template of a ck-macro (see
+      they are an unquoted top-level template of an eager macro (see
       below).  <code>Unquote-splicing</code> and nested
       quasiquotations are handled analogously to quasiquotation in the
       core Scheme language.
@@ -552,28 +519,28 @@ the following exceptions and additions:
       If the top-level template is an unquoted
       template <code>&lt;template&gt;</code>, the macro use is
       expanded as if it was a <code>syntax-rules</code> macro.  It is
-      an error if the expanded output is not a composable macro use
+      an error if the expanded output is not an eager macro use
       (or a self-quoting syntax element; see below).
     </p>
   </li>
   <li>
     <p>Syntax elements that are not proper lists are self-quoting.
-      Whenever they appear as input or output elements of ck-macros where
+      Whenever they appear as input or output elements of eager macros where
       a quoted syntax element is expected, they are implicitely quoted.
     </p>
   </li>
   <li>
     <p>
-      A ck-macro use is only allowed in definition contexts, except when
+      an eager macro use is only allowed in definition contexts, except when
       the macro use or top-level template of the macro is wrapped
-      into <code>ck-expression</code> (see also below) and does expand in an
+      into <code>em</code> (see also below) and does expand in an
       expression.
     </p>
   </li>
   <li>
     <p>
       When <code>&lt;pattern binding spec&gt;</code>s appear in a
-      ck-macro rule that is matched, the <code>&lt;pattern binding
+      eager macro rule that is matched, the <code>&lt;pattern binding
       spec&gt;</code>s are processed in left-to-right order before the final
       template of the rule is expanded: For each pattern binding
       spec <code>(&lt;template&gt; =&gt; &lt;top-level pattern
@@ -588,164 +555,164 @@ the following exceptions and additions:
   </li>
 </ul>
 
-<h2>CK-macros</h2>
+<h2>Eager macros</h2>
 
 <p>
-  In this subsection, all predefined ck-macros are listed.  It is
+  In this subsection, all predefined eager macros are listed.  It is
   not specified whether these macros are able to deal with circular lists and vectors.
 </p>
 
 <h3>Index</h3>
 
 <ul>
-  <li><a href="#General">General</a>: <a href="#ck-expression">ck-expression</a>,
-    <a href="#ck-cut">ck-cut</a>, <a href="#ck-cute">ck-cute</a>,
-    <a href="#ck-constant">ck-constant</a>, <a href="#ck-quote">ck-quote</a>,
-    <a href="#ck-eval">ck-eval</a>, <a href="#ck-apply">ck-apply</a>, <a href="#ck-call">ck-call</a>,
-    <a href="#ck-error">ck-error</a>,
-    <a href="#ck-gensym">ck-gensym</a>,
-    <a href="#ck-generate-temporaries">ck-generate-temporaries</a>
+  <li><a href="#General">General</a>: <a href="#em">em</a>,
+    <a href="#em-cut">em-cut</a>, <a href="#em-cute">em-cute</a>,
+    <a href="#em-constant">em-constant</a>, <a href="#em-quote">em-quote</a>,
+    <a href="#em-eval">em-eval</a>, <a href="#em-apply">em-apply</a>, <a href="#em-call">em-call</a>,
+    <a href="#em-error">em-error</a>,
+    <a href="#em-gensym">em-gensym</a>,
+    <a href="#em-generate-temporaries">em-generate-temporaries</a>
   </li>
   <li><a href="#Booleanlogic">Boolean logic</a>:
-    <a href="#ck-if">ck-if</a>,
-    <a href="#ck-not">ck-not</a>,
-    <a href="#ck-or">ck-or</a>,
-    <a href="#ck-and">ck-and</a>,
-    <a href="#ck-null?">ck-null?</a>,
-    <a href="#ck-pair?">ck-pair?</a>,
-    <a href="#ck-list?">ck-list?</a>,
-    <a href="#ck-boolean?">ck-boolean?</a>,
-    <a href="#ck-vector?">ck-vector?</a>,
-    <a href="#ck-symbol?">ck-symbol?</a>,
-    <a href="#ck-bound-identifier=?">ck-bound-identifier=?</a>,
-    <a href="#ck-free-identifier=?">ck-free-identifier=?</a>,
-    <a href="#ck-equal?">ck-equal?</a>
+    <a href="#em-if">em-if</a>,
+    <a href="#em-not">em-not</a>,
+    <a href="#em-or">em-or</a>,
+    <a href="#em-and">em-and</a>,
+    <a href="#em-null?">em-null?</a>,
+    <a href="#em-pair?">em-pair?</a>,
+    <a href="#em-list?">em-list?</a>,
+    <a href="#em-boolean?">em-boolean?</a>,
+    <a href="#em-vector?">em-vector?</a>,
+    <a href="#em-symbol?">em-symbol?</a>,
+    <a href="#em-bound-identifier=?">em-bound-identifier=?</a>,
+    <a href="#em-free-identifier=?">em-free-identifier=?</a>,
+    <a href="#em-equal?">em-equal?</a>
   </li>
   <li><a href="#Listprocessing">List processing</a>:
-    <a href="#ck-cons">ck-cons</a>,
-    <a href="#ck-cons*">ck-cons*</a>,
-    <a href="#ck-list">ck-list</a>,
-    <a href="#ck-make-list">ck-make-list</a>,
-    <a href="#ck-car">ck-car</a>,
-    <a href="#ck-cdr">ck-cdr</a>,
-    <a href="#ck-caar">ck-caar</a>,
-    <a href="#ck-cadr">ck-cadr</a>,
-    <a href="#ck-cdar">ck-cdar</a>,
-    <a href="#ck-cddr">ck-cddr</a>,
-    <a href="#ck-first">ck-first</a>,
-    <a href="#ck-second">ck-second</a>,
-    <a href="#ck-third">ck-third</a>,
-    <a href="#ck-fourth">ck-fourth</a>,
-    <a href="#ck-fifth">ck-fifth</a>,
-    <a href="#ck-sixth">ck-sixth</a>,
-    <a href="#ck-seventh">ck-seventh</a>,
-    <a href="#ck-eighth">ck-eighth</a>,
-    <a href="#ck-ninth">ck-ninth</a>,
-    <a href="#ck-tenth">ck-tenth</a>,
-    <a href="#ck-list-tail">ck-list-tail</a>,
-    <a href="#ck-list-ref">ck-list-ref</a>,
-    <a href="#ck-take">ck-take</a>,
-    <a href="#ck-drop">ck-drop</a>,
-    <a href="#ck-take-right">ck-take-right</a>,
-    <a href="#ck-drop-right">ck-drop-right</a>,
-    <a href="#ck-last">ck-last</a>,
-    <a href="#ck-last-pair">ck-last-pair</a>,
-    <a href="#ck-append">ck-append</a>,
-    <a href="#ck-reverse">ck-reverse</a>,
-    <a href="#ck-fold">ck-fold</a>,
-    <a href="#ck-fold-right">ck-fold-right</a>,
-    <a href="#ck-unfold">ck-unfold</a>,
-    <a href="#ck-unfold-right">ck-unfold-right</a>,
-    <a href="#ck-map">ck-map</a>,
-    <a href="#ck-append-map">ck-append-map</a>,
-    <a href="#ck-filter">ck-filter</a>,
-    <a href="#ck-remove">ck-remove</a>,
-    <a href="#ck-find">ck-find</a>,
-    <a href="#ck-find-tail">ck-find-tail</a>,
-    <a href="#ck-take-while">ck-take-while</a>,
-    <a href="#ck-drop-while">ck-drop-while</a>,
-    <a href="#ck-any">ck-any</a>,
-    <a href="#ck-every">ck-every</a>,
-    <a href="#ck-member">ck-member</a>,
-    <a href="#ck-assoc">ck-assoc</a>,
-    <a href="#ck-alist-delete">ck-alist-delete</a>,
-    <a href="#ck-set>=">ck-set&lt;=</a>,
-    <a href="#ck-set=">ck-set=</a>,
-    <a href="#ck-set-adjoin">ck-set-adjoin</a>,
-    <a href="#ck-set-union">ck-set-union</a>,
-    <a href="#ck-set-intersection">ck-set-intersection</a>,
-    <a href="#ck-set-difference">ck-set-difference</a>,
-    <a href="#ck-set-xor">ck-set-xor</a>
+    <a href="#em-cons">em-cons</a>,
+    <a href="#em-cons*">em-cons*</a>,
+    <a href="#em-list">em-list</a>,
+    <a href="#em-make-list">em-make-list</a>,
+    <a href="#em-car">em-car</a>,
+    <a href="#em-cdr">em-cdr</a>,
+    <a href="#em-caar">em-caar</a>,
+    <a href="#em-cadr">em-cadr</a>,
+    <a href="#em-cdar">em-cdar</a>,
+    <a href="#em-cddr">em-cddr</a>,
+    <a href="#em-first">em-first</a>,
+    <a href="#em-second">em-second</a>,
+    <a href="#em-third">em-third</a>,
+    <a href="#em-fourth">em-fourth</a>,
+    <a href="#em-fifth">em-fifth</a>,
+    <a href="#em-sixth">em-sixth</a>,
+    <a href="#em-seventh">em-seventh</a>,
+    <a href="#em-eighth">em-eighth</a>,
+    <a href="#em-ninth">em-ninth</a>,
+    <a href="#em-tenth">em-tenth</a>,
+    <a href="#em-list-tail">em-list-tail</a>,
+    <a href="#em-list-ref">em-list-ref</a>,
+    <a href="#em-take">em-take</a>,
+    <a href="#em-drop">em-drop</a>,
+    <a href="#em-take-right">em-take-right</a>,
+    <a href="#em-drop-right">em-drop-right</a>,
+    <a href="#em-last">em-last</a>,
+    <a href="#em-last-pair">em-last-pair</a>,
+    <a href="#em-append">em-append</a>,
+    <a href="#em-reverse">em-reverse</a>,
+    <a href="#em-fold">em-fold</a>,
+    <a href="#em-fold-right">em-fold-right</a>,
+    <a href="#em-unfold">em-unfold</a>,
+    <a href="#em-unfold-right">em-unfold-right</a>,
+    <a href="#em-map">em-map</a>,
+    <a href="#em-append-map">em-append-map</a>,
+    <a href="#em-filter">em-filter</a>,
+    <a href="#em-remove">em-remove</a>,
+    <a href="#em-find">em-find</a>,
+    <a href="#em-find-tail">em-find-tail</a>,
+    <a href="#em-take-while">em-take-while</a>,
+    <a href="#em-drop-while">em-drop-while</a>,
+    <a href="#em-any">em-any</a>,
+    <a href="#em-every">em-every</a>,
+    <a href="#em-member">em-member</a>,
+    <a href="#em-assoc">em-assoc</a>,
+    <a href="#em-alist-delete">em-alist-delete</a>,
+    <a href="#em-set>=">em-set&lt;=</a>,
+    <a href="#em-set=">em-set=</a>,
+    <a href="#em-set-adjoin">em-set-adjoin</a>,
+    <a href="#em-set-union">em-set-union</a>,
+    <a href="#em-set-intersection">em-set-intersection</a>,
+    <a href="#em-set-difference">em-set-difference</a>,
+    <a href="#em-set-xor">em-set-xor</a>
   </li>
   <li>
     <a href="#Vectorprocessing">Vector processing</a>:
-    <a href="#ck-vector">ck-vector</a>,
-    <a href="#ck-list->vector">ck-list-&gt;vector</a>,
-    <a href="#ck-vector->list">ck-vector-&gt;list</a>,
-    <a href="#ck-vector-map">ck-vector-map</a>,
-    <a href="#ck-vector-ref">ck-vector-ref</a>,
+    <a href="#em-vector">em-vector</a>,
+    <a href="#em-list->vector">em-list-&gt;vector</a>,
+    <a href="#em-vector->list">em-vector-&gt;list</a>,
+    <a href="#em-vector-map">em-vector-map</a>,
+    <a href="#em-vector-ref">em-vector-ref</a>,
   </li>
   <li>
     <a href="#Combinatorics">Combinatorics</a>:
-    <a href="#ck-0">ck-0</a>,
-    <a href="#ck-1">ck-1</a>,
-    <a href="#ck-2">ck-2</a>,
-    <a href="#ck-3">ck-3</a>,
-    <a href="#ck-4">ck-4</a>,
-    <a href="#ck-5">ck-5</a>,
-    <a href="#ck-6">ck-6</a>,
-    <a href="#ck-7">ck-7</a>,
-    <a href="#ck-8">ck-8</a>,
-    <a href="#ck-9">ck-9</a>,
-    <a href="#ck-10">ck-10</a>,
-    <a href="#ck-=">ck-=</a>,
-    <a href="#ck-<;">ck-&lt;</a>,
-    <a href="#ck-<=">ck-&lt;=</a>,
-    <a href="#ck->">ck-&gt;</a>,
-    <a href="#ck->=">ck-&gt;=</a>,
-    <a href="#ck-zero?">ck-zero?</a>,
-    <a href="#ck-even?">ck-even?</a>,
-    <a href="#ck-odd?">ck-odd?</a>,
-    <a href="#ck-+">ck-+</a>,
-    <a href="#ck--">ck--</a>,
-    <a href="#ck-*">ck-*</a>,
-    <a href="#ck-quotient">ck-quotient</a>,
-    <a href="#ck-remainder">ck-remainder</a>,
-    <a href="#ck-fact">ck-fact</a>,
-    <a href="#ck-binom">ck-binom</a>
+    <a href="#em-0">em-0</a>,
+    <a href="#em-1">em-1</a>,
+    <a href="#em-2">em-2</a>,
+    <a href="#em-3">em-3</a>,
+    <a href="#em-4">em-4</a>,
+    <a href="#em-5">em-5</a>,
+    <a href="#em-6">em-6</a>,
+    <a href="#em-7">em-7</a>,
+    <a href="#em-8">em-8</a>,
+    <a href="#em-9">em-9</a>,
+    <a href="#em-10">em-10</a>,
+    <a href="#em=">em=</a>,
+    <a href="#em<;">em&lt;</a>,
+    <a href="#em<=">em&lt;=</a>,
+    <a href="#em>">em&gt;</a>,
+    <a href="#em>=">em&gt;=</a>,
+    <a href="#em-zero?">em-zero?</a>,
+    <a href="#em-even?">em-even?</a>,
+    <a href="#em-odd?">em-odd?</a>,
+    <a href="#em+">em+</a>,
+    <a href="#em-">em-</a>,
+    <a href="#em*">em*</a>,
+    <a href="#em-quotient">em-quotient</a>,
+    <a href="#em-remainder">em-remainder</a>,
+    <a href="#em-fact">em-fact</a>,
+    <a href="#em-binom">em-binom</a>
   </li>
 </ul>
 
 <h3 id="General">General</h3>
 
-<p id="ck-expression"><code>(ck-expression &lt;ck-macro use&gt;)</code></p>
+<p id="em"><code>(em &lt;eager macro use&gt;)</code></p>
 
-<p>Expands into the expansion of &lt;ck-macro use&gt; with the
+<p>Expands into the expansion of &lt;eager macro use&gt; with the
   additional property that it is allowed in an expression context.  It
-  is an error if &lt;ck-macro use&gt; does not expand into a
+  is an error if &lt;eager macro use&gt; does not expand into a
   expression.</p>
 
-<p><i>Rationale: That ck-macro uses that expand into expressions have
-    to be wrapped in <code>ck-expression</code> forms to ensure
+<p><i>Rationale: That eager macro uses that expand into expressions have
+    to be wrapped in <code>em</code> forms to ensure
     that this SRFI can be portably implemented.  If Scheme had
     a <code>let(rec)-syntax</code> form that spliced its body into the
-    outer scope, this auxiliary <code>ck-expression</code> wouldn't be necessary.</i>
+    outer scope, this auxiliary <code>em</code> wouldn't be necessary.</i>
 </p>
 
-<p id="ck-cut"><code>(ck-cut &lt;slot or ck-macro datum&gt;<sub>1</sub> &lt;slot or
-ck-macro datum&gt;<sub>2</sub> ...)</code></p>
-<p><code>(ck-cut &lt;slot or ck-macro datum&gt;<sub>1</sub> &lt;slot or
-ck-macro datum&gt;<sub>2</sub> ... &lt;&gt; &lt;ellipsis&gt;)</code></p>
+<p id="em-cut"><code>(em-cut &lt;slot or eager macro datum&gt;<sub>1</sub> &lt;slot or
+eager macro datum&gt;<sub>2</sub> ...)</code></p>
+<p><code>(em-cut &lt;slot or eager macro datum&gt;<sub>1</sub> &lt;slot or
+eager macro datum&gt;<sub>2</sub> ... &lt;&gt; &lt;ellipsis&gt;)</code></p>
 
 <p>
-  Expands into a ck-macro that accepts as many input elements as there are slots (elements of the form
-  <code>&lt;&gt;</code>) amongst the <code>&lt;ck-macro
-    datum&gt;</code>s.  When this ck-macro is used, it expands into the expansion of
-  <code>(&lt;slot or ck-macro datum&gt;<sub>1</sub> &lt;slot or
-    ck-macro datum&gt;<sub>2</sub>)</code> where the slots are
+  Expands into an eager macro that accepts as many input elements as there are slots (elements of the form
+  <code>&lt;&gt;</code>) amongst the <code>&lt;eager macro
+    datum&gt;</code>s.  When this eager macro is used, it expands into the expansion of
+  <code>(&lt;slot or eager macro datum&gt;<sub>1</sub> &lt;slot or
+    eager macro datum&gt;<sub>2</sub>)</code> where the slots are
     replaced by its input elements in order.  In case of the second
     syntax with <code>(... &lt;&gt; &lt;ellipsis&gt;)</code>, the
-    resulting ck-macro takes a variable number of extra input elements
+    resulting eager macro takes a variable number of extra input elements
     that are spliced in place of the sequence <code>&lt;&gt;
     &lt;ellipsis&gt</code>.  (The semantics are analogous to the
     semantics of the <code>cut</code> macro
@@ -753,87 +720,87 @@ ck-macro datum&gt;<sub>2</sub> ... &lt;&gt; &lt;ellipsis&gt;)</code></p>
     except for that <code>&lt;...&gt;</code> is replaced by the
     sequence <code>&lt;&gt; &lt;ellipsis&gt;</code>, which would not
     have been possible to implement when SRFI 26 was finalized).  It
-    is an error to use <code>ck-cut</code> standalone, that is, not as
-    an input or output element of a ck-macro.
+    is an error to use <code>em-cut</code> standalone, that is, not as
+    an input or output element of an eager macro.
 </p>
 
-<p id="ck-cute"><code>(ck-cute &lt;slot or ck-macro datum&gt;<sub>1</sub> &lt;slot or
-ck-macro datum&gt;<sub>2</sub> ...)</code></p>
-<p><code>(ck-cute &lt;slot or ck-macro datum&gt;<sub>1</sub> &lt;slot or
-ck-macro datum&gt;<sub>2</sub> ... &lt;&gt; &lt;ellipsis&gt;)</code></p>
+<p id="em-cute"><code>(em-cute &lt;slot or eager macro datum&gt;<sub>1</sub> &lt;slot or
+eager macro datum&gt;<sub>2</sub> ...)</code></p>
+<p><code>(em-cute &lt;slot or eager macro datum&gt;<sub>1</sub> &lt;slot or
+eager macro datum&gt;<sub>2</sub> ... &lt;&gt; &lt;ellipsis&gt;)</code></p>
 
 <p>
-  Analogous to the <code>ck-cut</code>-macro uses, except that the non-slot 
-  <code>&lt;slot or ck-macro datum&gt;</code>s are expanded when
-  the <code>ck-cute</code>-macro use is expanded, not when the
-  resulting ck-macro is expanded.
+  Analogous to the <code>em-cut</code>-macro uses, except that the non-slot 
+  <code>&lt;slot or eager macro datum&gt;</code>s are expanded when
+  the <code>em-cute</code>-macro use is expanded, not when the
+  resulting eager macro is expanded.
   (The semantics are analogous to the semantics of
     the <code>cute</code> macro
   of <a href="srfi.schemers.org/srfi-26/srfi-26.html">SRFI 26</a>).
-  It is an error to use <code>ck-cute</code> standalone, that is, not
-  as an input or output element of a ck-macro.
+  It is an error to use <code>em-cute</code> standalone, that is, not
+  as an input or output element of an eager macro.
 </p>
 
 <p><i>Rationale: While the <code>cut</code> and <code>cute</code>
     macros of SRFI 26 are not really essential for coding in Scheme
     because Scheme has closures, there is no such thing as closures of
-    ck-macros.  However, <code>ck-cut</code>
-    and <code>ck-cute</code> can be used to emulate closures.
+    eager macros.  However, <code>em-cut</code>
+    and <code>em-cute</code> can be used to emulate closures.
   </i>
 </p>
 
-<p id="ck-constant"><code>(ck-constant &lt;constant&gt;)</code></p>
+<p id="em-constant"><code>(em-constant &lt;constant&gt;)</code></p>
 
 <p>
-  Expands into a ck-macro that accepts an arbitrary number of input
+  Expands into an eager macro that accepts an arbitrary number of input
   elements and that always expands into the expansion of &lt;constant&gt;.
 
   It
-  is an error to use <code>ck-constant</code> standalone, that is, not as
-  an input or output element of a ck-macro.
+  is an error to use <code>em-constant</code> standalone, that is, not as
+  an input or output element of an eager macro.
 </p>
 
-<p id="ck-quote"><code>(ck-quote &lt;ck-macro datum&gt;)</code></p>
+<p id="em-quote"><code>(em-quote &lt;eager macro datum&gt;)</code></p>
 
-<p>Expands into the quotation of the expansion of the <code>&lt;ck-macro datum&gt;</code>.</p>
+<p>Expands into the quotation of the expansion of the <code>&lt;eager macro datum&gt;</code>.</p>
 
-<p id="ck-eval"><code>(ck-eval &lt;ck-macro datum&gt;)</code></p>
+<p id="em-eval"><code>(em-eval &lt;eager macro datum&gt;)</code></p>
 
-<p>Expands into the expansion of the expansion of &lt;ck-macro datum&gt;.</p>
+<p>Expands into the expansion of the expansion of &lt;eager macro datum&gt;.</p>
 
-<p><code>(ck-apply &lt;ck-macro datum&gt;<sub>1</sub> &lt;ck-macro datum&gt;... &lt;ck-macro datum&gt;<sub>2</sub>)</code></p>
-
-<p>Semantically equivalent to:</p>
-
-<pre>
- (ck-append (ck-list &lt;ck-macro datum&gt;<sub>1</sub> &lt;ck-macro datum&gt; ...) &lt;ck-macro datum&gt;<sub>2</sub>)
-</pre>
-
-<p>It is an error if <code>&lt;ck-macro datum&gt;<sub>2</sub></code> does not expand into a list.</p>
-
-<p id="ck-call"><code>(ck-call &lt;macro&gt; &lt;input&gt; ...)</code></p>
+<p><code>(em-apply &lt;eager macro datum&gt;<sub>1</sub> &lt;eager macro datum&gt;... &lt;eager macro datum&gt;<sub>2</sub>)</code></p>
 
 <p>Semantically equivalent to:</p>
 
 <pre>
- (ck-apply &lt;macro&gt; &lt;input&gt; ... '())
+ (em-append (em-list &lt;eager macro datum&gt;<sub>1</sub> &lt;eager macro datum&gt; ...) &lt;eager macro datum&gt;<sub>2</sub>)
 </pre>
 
-<p id="ck-error"><code>(ck-error &lt;message&gt; &lt;argument&gt; ...)</code></p>
+<p>It is an error if <code>&lt;eager macro datum&gt;<sub>2</sub></code> does not expand into a list.</p>
+
+<p id="em-call"><code>(em-call &lt;macro&gt; &lt;input&gt; ...)</code></p>
+
+<p>Semantically equivalent to:</p>
+
+<pre>
+ (em-apply &lt;macro&gt; &lt;input&gt; ... '())
+</pre>
+
+<p id="em-error"><code>(em-error &lt;message&gt; &lt;argument&gt; ...)</code></p>
 
 <p>Expansion yields a syntax error whose message is the expansion
   of <code>&lt;message&gt;</code> and whose
   arguments are the expansions of the <code>&lt;argument&gt;</code>s.
 </p>
 
-<p id="ck-gensym"><code>(ck-gensym)</code></p>
+<p id="em-gensym"><code>(em-gensym)</code></p>
 
 <p>Expands into a fresh identifier that is
-  not <code>ck-bound-identifier=?</code> (see below) to any existing
+  not <code>em-bound-identifier=?</code> (see below) to any existing
   already existing identifier.
 </p>
 
-<p id="ck-generate-temporaries"><code>(ck-generate-temporaries &lt;list&gt;)</code></p>
+<p id="em-generate-temporaries"><code>(em-generate-temporaries &lt;list&gt;)</code></p>
 
 <p>Expands into a list of pairwise different (in the sense of <code>bound-identifier=?</code>)
   identifiers whose length is the number of elements in the expansion of <code>&lt;list&gt;</code>
@@ -842,81 +809,81 @@ ck-macro datum&gt;<sub>2</sub> ... &lt;&gt; &lt;ellipsis&gt;)</code></p>
 
 <h3 id="Booleanlogic">Boolean logic</h3>
 
-<p id="ck-if"><code>(ck-if &lt;ck-macro datum&gt;<sub>1</sub>
-&lt;ck-macro datum&gt;<sub>2</sub> &lt;ck-macro
+<p id="em-if"><code>(em-if &lt;eager macro datum&gt;<sub>1</sub>
+&lt;eager macro datum&gt;<sub>2</sub> &lt;eager macro
 datum&gt;<sub>3</sub>)</code></p>
 
-<p>Expands into the expansion of <code>&lt;ck-macro datum&gt;<sub>2</sub></code> if
-  <code>&lt;ck-macro datum&gt;<sub>1</sub></code> does not expand
-  into <code>#f</code>, and into the expansion of <code>&lt;ck-macro
+<p>Expands into the expansion of <code>&lt;eager macro datum&gt;<sub>2</sub></code> if
+  <code>&lt;eager macro datum&gt;<sub>1</sub></code> does not expand
+  into <code>#f</code>, and into the expansion of <code>&lt;eager macro
     datum&gt;<sub>3</sub></code> otherwise.
 </p>
 
-<p id="ck-not"><code>(ck-not &lt;ck-macro datum&gt;)</code></p>
+<p id="em-not"><code>(em-not &lt;eager macro datum&gt;)</code></p>
 
-<p>Expands into <code>#f</code> if <code>&lt;ck-macro datum&gt;</code>
+<p>Expands into <code>#f</code> if <code>&lt;eager macro datum&gt;</code>
 does not expand into <code>#f</code>, and into <code>#t</code> otherwise.
 </p>
 
-<p id="ck-or"><code>(ck-or &lt;ck-macro datum&gt;)</code></p>
+<p id="em-or"><code>(em-or &lt;eager macro datum&gt; ...)</code></p>
 
-<p>Expands into the expansion of the first <code>&lt;ck-macro
+<p>Expands into the expansion of the first <code>&lt;eager macro
     datum&gt;</code> (in left-to-right order) that does not expand
     into <code>#f</code>, and does not expand any
-    later <code>&lt;ck-macro datum&gt;</code>s; expands
-    into <code>#f</code> if all <code>&lt;ck-macro datum&gt;</code>s
+    later <code>&lt;eager macro datum&gt;</code>s; expands
+    into <code>#f</code> if all <code>&lt;eager macro datum&gt;</code>s
     expand into <code>#f</code>.
 </p>
 
-<p id="ck-and"><code>(ck-and &lt;ck-macro datum&gt;)</code></p>
+<p id="em-and"><code>(em-and &lt;eager macro datum&gt; ...)</code></p>
 
-<p>Expands into the expansion of the last <code>&lt;ck-macro
+<p>Expands into the expansion of the last <code>&lt;eager macro
     datum&gt;</code> (in left-to-right order) if all previous
-    <code>&lt;ck-macro datum&gt;</code>s do not expand
-    into <code>#f</code>, and does not expand any <code>&lt;ck-macro
+    <code>&lt;eager macro datum&gt;</code>s do not expand
+    into <code>#f</code>, and does not expand any <code>&lt;eager macro
     datum&gt;</code>s after the first that expands
     into <code>#f</code>; expands into <code>#f</code> otherwise.
 </p>
 
-<p id="ck-null?"><code>(ck-null? &lt;ck-macro datum&gt;)</code></p>
+<p id="em-null?"><code>(em-null? &lt;eager macro datum&gt;)</code></p>
 
-<p>Expands into <code>#t</code> if <code>&lt;ck-macro datum&gt;</code>
+<p>Expands into <code>#t</code> if <code>&lt;eager macro datum&gt;</code>
 expands into the empty list, and into <code>#f</code> otherwise.
 </p>
 
-<p id="ck-pair?"><code>(ck-pair? &lt;ck-macro datum&gt;)</code></p>
+<p id="em-pair?"><code>(em-pair? &lt;eager macro datum&gt;)</code></p>
 
-<p>Expands into <code>#t</code> if <code>&lt;ck-macro datum&gt;</code>
+<p>Expands into <code>#t</code> if <code>&lt;eager macro datum&gt;</code>
 expands into a pair, and into <code>#f</code> otherwise.
 </p>
 
 
-<p id="ck-list?"><code>(ck-list? &lt;ck-macro datum&gt;)</code></p>
+<p id="em-list?"><code>(em-list? &lt;eager macro datum&gt;)</code></p>
 
-<p>Expands into <code>#t</code> if <code>&lt;ck-macro datum&gt;</code>
+<p>Expands into <code>#t</code> if <code>&lt;eager macro datum&gt;</code>
 expands into a (proper) list, and into <code>#f</code> otherwise.
 </p>
 
-<p id="ck-boolean?"><code>(ck-boolean? &lt;ck-macro datum&gt;)</code></p>
+<p id="em-boolean?"><code>(em-boolean? &lt;eager macro datum&gt;)</code></p>
 
-<p>Expands into <code>#t</code> if <code>&lt;ck-macro datum&gt;</code>
+<p>Expands into <code>#t</code> if <code>&lt;eager macro datum&gt;</code>
 expands into a boolean literal, and into <code>#f</code> otherwise.
 </p>
 
-<p id="ck-vector?"><code>(ck-vector? &lt;ck-macro datum&gt;)</code></p>
+<p id="em-vector?"><code>(em-vector? &lt;eager macro datum&gt;)</code></p>
 
-<p>Expands into <code>#t</code> if <code>&lt;ck-macro datum&gt;</code>
+<p>Expands into <code>#t</code> if <code>&lt;eager macro datum&gt;</code>
 expands into a vector literal, and into <code>#f</code> otherwise.
 </p>
 
-<p id="ck-symbol?"><code>(ck-symbol? &lt;ck-macro datum&gt;)</code></p>
+<p id="em-symbol?"><code>(em-symbol? &lt;eager macro datum&gt;)</code></p>
 
 <p>
-  Expands into <code>#t</code> if <code>&lt;ck-macro datum&gt;</code>
+  Expands into <code>#t</code> if <code>&lt;eager macro datum&gt;</code>
   expands into a symbol, and into <code>#f</code> otherwise.
 </p>
 
-<p id="ck-bound-identifier=?"><code>(ck-bound-identifier=? &lt;identifier&gt;
+<p id="em-bound-identifier=?"><code>(em-bound-identifier=? &lt;identifier&gt;
     &lt;input&gt;)</code></p>
 
 <p>
@@ -928,7 +895,7 @@ expands into a vector literal, and into <code>#f</code> otherwise.
   expand into a symbol.
 </p>
 
-<p id="ck-free-identifier=?"><code>(ck-free-identifier=? &lt;identifier&gt;<sub>1</sub>
+<p id="em-free-identifier=?"><code>(em-free-identifier=? &lt;identifier&gt;<sub>1</sub>
     &lt;identifier&gt;<sub>1</sub>)</code></p>
 
 <p>
@@ -942,23 +909,23 @@ expands into a vector literal, and into <code>#f</code> otherwise.
   symbol.
 </p>
 
-<p id="ck-equal?"><code>(ck-equal? &lt;ck-macro datum&gt;<sub>1</sub>
-    &lt;ck-macro datum&gt;<sub>2</sub>)</code></p>
+<p id="em-equal?"><code>(em-equal? &lt;eager macro datum&gt;<sub>1</sub>
+    &lt;eager macro datum&gt;<sub>2</sub>)</code></p>
 
 <p>
-  Expands into <code>#t</code> if <code>&lt;ck-macro
-    datum&gt;</code><sub>1</sub> and <code>&lt;ck-macro
+  Expands into <code>#t</code> if <code>&lt;eager macro
+    datum&gt;</code><sub>1</sub> and <code>&lt;eager macro
     datum&gt;</code><sub>2</sub> are the same, and
     into <code>#f</code> otherwise.  Pairs and vectors are compared
     recursively, and symbols are compared
-  using <code>ck-bound-identifier=?</code>.
+  using <code>em-bound-identifier=?</code>.
 </p>
 
 <h3 id="Listprocessing">List processing</h3>
 
 <h4>Constructors</h4>
 
-<p id="ck-cons"><code>(ck-cons &lt;input&gt;<sub>1</sub> &lt;input&gt;<sub>2</sub>)</code></p>
+<p id="em-cons"><code>(em-cons &lt;input&gt;<sub>1</sub> &lt;input&gt;<sub>2</sub>)</code></p>
 
 <p>
   Expands into a pair whose car is the expansion
@@ -966,18 +933,18 @@ expands into a vector literal, and into <code>#f</code> otherwise.
   the expansion of <code>&lt;input&gt;<sub>2</sub></code>.
 </p>
 
-<p id="ck-cons*"><code>(ck-cons* &lt;element&gt; ... &lt;tail&gt;)</code></p>
+<p id="em-cons*"><code>(em-cons* &lt;element&gt; ... &lt;tail&gt;)</code></p>
 
 <p>Expands into the expansion of <code>`(,&lt;element&gt; ... . ,&lt;tail&gt;)</code></p>
 
-<p id="ck-list"><code>(ck-list &lt;element&gt; ...)</code></p>
+<p id="em-list"><code>(em-list &lt;element&gt; ...)</code></p>
 
 <p>
   Expands into a list whose elements are the expansions of the 
   <code>&lt;elements&gt;</code>s.
 </p>
 
-<p id="ck-make-list"><code>(ck-make-list &lt;k&gt; &lt;element&gt;)</code></p>
+<p id="em-make-list"><code>(em-make-list &lt;k&gt; &lt;element&gt;)</code></p>
 
 <p>
   Expands into a list whose length is the length of the expansion of
@@ -988,42 +955,42 @@ expands into a vector literal, and into <code>#f</code> otherwise.
 
 <h4>Selectors</h4>
 
-<p id="ck-car"><code>(ck-car &lt;pair&gt;)</code></p>
+<p id="em-car"><code>(em-car &lt;pair&gt;)</code></p>
 
 <p>
   Expands into the car of the expansion of  <code>&lt;pair&gt;</code>.  It is an error if
   <code>&lt;pair&gt;</code> does not expand into a pair.
 </p>
 
-<p id="ck-cdr"><code>(ck-cdr &lt;pair&gt;)</code></p>
+<p id="em-cdr"><code>(em-cdr &lt;pair&gt;)</code></p>
 
 <p>
   Expands into the cdr of the expansion of  <code>&lt;pair&gt;</code>.  It is an error if
   <code>&lt;pair&gt;</code> does not expand into a pair.
 </p>
 
-<p id="ck-caar"><code>(ck-caar &lt;pair&gt;)</code></p>
-<p id="ck-cadr"><code>(ck-cadr &lt;pair&gt;)</code></p>
-<p id="ck-cdar"><code>(ck-cdar &lt;pair&gt;)</code></p>
-<p id="ck-cddr"><code>(ck-cddr &lt;pair&gt;)</code></p>
+<p id="em-caar"><code>(em-caar &lt;pair&gt;)</code></p>
+<p id="em-cadr"><code>(em-cadr &lt;pair&gt;)</code></p>
+<p id="em-cdar"><code>(em-cdar &lt;pair&gt;)</code></p>
+<p id="em-cddr"><code>(em-cddr &lt;pair&gt;)</code></p>
  
 <p>
-  Semantically equivalent to <code>(ck-car (ck-car
-    &lt;pair&gt;))</code>, <code>(ck-car (ck-cdr
-    &lt;pair&gt;))</code>, <code>(ck-cdr (ck-car &lt;pair&gt;))</code>, 
-  <code>(ck-cdr (ck-cdr &lt;pair&gt;))</code>.
+  Semantically equivalent to <code>(em-car (em-car
+    &lt;pair&gt;))</code>, <code>(em-car (em-cdr
+    &lt;pair&gt;))</code>, <code>(em-cdr (em-car &lt;pair&gt;))</code>, 
+  <code>(em-cdr (em-cdr &lt;pair&gt;))</code>.
 </p>
 
-<p id="ck-first"><code>(ck-first &lt;list&gt; ...)</code></p>
-<p id="ck-second"><code>(ck-second &lt;list&gt; ...)</code></p>
-<p id="ck-third"><code>(ck-third &lt;list&gt; ...)</code></p>
-<p id="ck-fourth"><code>(ck-fourth &lt;list&gt; ...)</code></p>
-<p id="ck-fifth"><code>(ck-fifth &lt;list&gt; ...)</code></p>
-<p id="ck-sixth"><code>(ck-sixth &lt;list&gt; ...)</code></p>
-<p id="ck-seventh"><code>(ck-seventh &lt;list&gt; ...)</code></p>
-<p id="ck-eighth"><code>(ck-eighth &lt;list&gt; ...)</code></p>
-<p id="ck-ninth"><code>(ck-ninth &lt;list&gt; ...)</code></p>
-<p id="ck-tenth"><code>(ck-tenth &lt;list&gt; ...)</code></p>
+<p id="em-first"><code>(em-first &lt;list&gt; ...)</code></p>
+<p id="em-second"><code>(em-second &lt;list&gt; ...)</code></p>
+<p id="em-third"><code>(em-third &lt;list&gt; ...)</code></p>
+<p id="em-fourth"><code>(em-fourth &lt;list&gt; ...)</code></p>
+<p id="em-fifth"><code>(em-fifth &lt;list&gt; ...)</code></p>
+<p id="em-sixth"><code>(em-sixth &lt;list&gt; ...)</code></p>
+<p id="em-seventh"><code>(em-seventh &lt;list&gt; ...)</code></p>
+<p id="em-eighth"><code>(em-eighth &lt;list&gt; ...)</code></p>
+<p id="em-ninth"><code>(em-ninth &lt;list&gt; ...)</code></p>
+<p id="em-tenth"><code>(em-tenth &lt;list&gt; ...)</code></p>
 
 <p>
   Expands into the first, second, third, ... element of the expansion
@@ -1033,9 +1000,9 @@ expands into a vector literal, and into <code>#f</code> otherwise.
   <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>).
 </p>
 
-<p id="ck-list-tail"><code>(ck-list-tail &lt;list&gt; &lt;k&gt;)</code></p>
+<p id="em-list-tail"><code>(em-list-tail &lt;list&gt; &lt;k&gt;)</code></p>
 
-<p id="ck-list-ref"><code>(ck-list-ref &lt;list&gt; &lt;k&gt;)</code></p>
+<p id="em-list-ref"><code>(em-list-ref &lt;list&gt; &lt;k&gt;)</code></p>
 
 <p>
   Expands into the <em>k</em>th element of the expansion
@@ -1045,7 +1012,7 @@ expands into a vector literal, and into <code>#f</code> otherwise.
   and <code>&lt;k&gt;</code> do not expand into lists.
 </p>
 
-<p id="ck-take"><code>(ck-take &lt;list&gt; &lt;k&gt;)</code></p>
+<p id="em-take"><code>(em-take &lt;list&gt; &lt;k&gt;)</code></p>
 
 <p>
   Expands into the sublist consisting of the first <em>k</em> elements
@@ -1057,7 +1024,7 @@ expands into a vector literal, and into <code>#f</code> otherwise.
   <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.)
 </p>
 
-<p id="ck-drop"><code>(ck-drop &lt;list&gt; &lt;k&gt;)</code></p>
+<p id="em-drop"><code>(em-drop &lt;list&gt; &lt;k&gt;)</code></p>
 
 <p>
   Expands into the sublist of the expansion
@@ -1065,12 +1032,12 @@ expands into a vector literal, and into <code>#f</code> otherwise.
   on the left as the expansion of <code>&lt;k&gt;<sub>2</sub></code>
   has elements.  It is an error if <code>&lt;list&gt;</code>
   and <code>&lt;k&gt;</code> do not expand into lists.
-  (<code>Ck-drop</code> is an alternative name to <code>list-tail</code>, analogously
+  (<code>Em-drop</code> is an alternative name to <code>list-tail</code>, analogously
   to <code>drop</code> from
   <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.)
 </p>
 
-<p id="ck-take-right"><code>(ck-take-right &lt;list&gt;
+<p id="em-take-right"><code>(em-take-right &lt;list&gt;
 &lt;k&gt;)</code></p>
 
 <p>
@@ -1084,7 +1051,7 @@ expands into a vector literal, and into <code>#f</code> otherwise.
   <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.)
 </p>
 
-<p id="ck-drop-right"><code>(ck-drop-right &lt;list&gt; &lt;k&gt;)</code></p>
+<p id="em-drop-right"><code>(em-drop-right &lt;list&gt; &lt;k&gt;)</code></p>
 
 <p>
   Expands into the sublist consisting of all but the last <em>k</em>
@@ -1097,7 +1064,7 @@ expands into a vector literal, and into <code>#f</code> otherwise.
   <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.)
 </p>
 
-<p id="ck-last"><code>(ck-last &lt;pair&gt;)</code></p>
+<p id="em-last"><code>(em-last &lt;pair&gt;)</code></p>
 
 <p>Expands into the last element of the expansion
   of <code>&lt;pair&gt;</code>.  It is an error
@@ -1106,7 +1073,7 @@ expands into a vector literal, and into <code>#f</code> otherwise.
   <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.)
 <p>
 
-<p id="ck-last-pair"><code>(ck-last-pair &lt;pair&gt;)</code></p>
+<p id="em-last-pair"><code>(em-last-pair &lt;pair&gt;)</code></p>
 
 <p>Expands into the last pair of the expansion
   of <code>&lt;pair&gt;</code>.  It is an error
@@ -1117,7 +1084,7 @@ expands into a vector literal, and into <code>#f</code> otherwise.
 
 <h4>Miscellaneous</h4>
 
-<p id="ck-append"><code>(ck-append &lt;list&gt; ...)</code></p>
+<p id="em-append"><code>(em-append &lt;list&gt; ...)</code></p>
 
 <p>
   Expands into a (possibly improper) list that is the concatenation of the
@@ -1126,7 +1093,7 @@ expands into a vector literal, and into <code>#f</code> otherwise.
   expand into a proper list.
 </p>
 
-<p id="ck-reverse"><code>(ck-reverse &lt;list&gt;)</code></p>
+<p id="em-reverse"><code>(em-reverse &lt;list&gt;)</code></p>
 
 <p>Expands into a list whose elements are the elements of the
   expansion of <code>&lt;list&gt;</code> in reverse order.  It is an
@@ -1135,13 +1102,13 @@ expands into a vector literal, and into <code>#f</code> otherwise.
 
 <h4>Folding, unfolding and mapping</h4>
 
-<p id="ck-fold"><code>(ck-fold &lt;proc&gt; &lt;nil&gt; &lt;list&gt; ...)</code></p>
+<p id="em-fold"><code>(em-fold &lt;proc&gt; &lt;nil&gt; &lt;list&gt; ...)</code></p>
 
 <p>
   Expands into the expansion &lt;nil&gt; if at least one of
   the <code>&lt;list&gt;</code>s expands into the empty list.  Expands
-  into the expansion of <code>(ck-fold &lt;proc&gt; (ck-call
-  &lt;proc&gt; (ck-car &lt;list&gt;) ... &lt;nil&gt;) (ck-cdr
+  into the expansion of <code>(em-fold &lt;proc&gt; (em-call
+  &lt;proc&gt; (em-car &lt;list&gt;) ... &lt;nil&gt;) (em-cdr
   &lt;list&gt;) ...)</code> otherwise.
 					      
   It is an error if the <code>&lt;list&gt;</code>s do not expand into lists.
@@ -1151,68 +1118,68 @@ expands into a vector literal, and into <code>#f</code> otherwise.
   1</a>.)
 </p>
 
-<p id="ck-fold-right"><code>(ck-fold-right &lt;proc&gt; &lt;nil&gt; &lt;list&gt; ...)</code></p>
+<p id="em-fold-right"><code>(em-fold-right &lt;proc&gt; &lt;nil&gt; &lt;list&gt; ...)</code></p>
 
 <p>
   Expands into the expansion &lt;nil&gt; if at least one of
   the <code>&lt;list&gt;</code>s expands into the empty list.  Expands
-  into the expansion of <code>(ck-call &lt;proc&gt;
-  (ck-car &lt;list&gt;) ...  (ck-fold-right &lt;proc&gt; &lt;nil&gt;
-  (ck-cdr &lt;list&gt;) ...))</code> otherwise.  It is an error if
+  into the expansion of <code>(em-call &lt;proc&gt;
+  (em-car &lt;list&gt;) ...  (em-fold-right &lt;proc&gt; &lt;nil&gt;
+  (em-cdr &lt;list&gt;) ...))</code> otherwise.  It is an error if
   the <code>&lt;list&gt;</code>s do not expand into lists.
   (Analogous to <code>fold-right</code>
   from <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI
   1</a>.)
 </p>
 
-<p id="ck-unfold"><code>(ck-unfold &lt;stop?&gt; &lt;mapper&gt; &lt;successor&gt;
+<p id="em-unfold"><code>(em-unfold &lt;stop?&gt; &lt;mapper&gt; &lt;successor&gt;
 &lt;seed&gt; &lt;tail-mapper&gt;)</code></p>
-<p><code>(ck-unfold &lt;stop??&gt; &lt;mapper&gt; &lt;successor&gt; &lt;seed&gt;)</code></p>
+<p><code>(em-unfold &lt;stop??&gt; &lt;mapper&gt; &lt;successor&gt; &lt;seed&gt;)</code></p>
 
 <p>
   Expands into the expansion of <code>(&lt;tail-mapper&gt;
   &lt;seed&gt;)</code> if (<code>&lt;stop?&gt; &lt;seed&gt;</code>) does not expand
-  into <code>#f</code>.  Expands into the expansion of <code>(ck-cons (&lt;mapper&gt; &lt;seed&gt;)
-    (ck-unfold &lt;stop?&gt; &lt;mapper&gt; &lt;successor&gt; (&lt;successor&gt; &lt;seed&gt;)
+  into <code>#f</code>.  Expands into the expansion of <code>(em-cons (&lt;mapper&gt; &lt;seed&gt;)
+    (em-unfold &lt;stop?&gt; &lt;mapper&gt; &lt;successor&gt; (&lt;successor&gt; &lt;seed&gt;)
     &lt;tail-mapper&gt;)</code> otherwise.
-  If <code>&lt;tail-mapper&gt;</code> is omitted, it defaults to <code>(ck-constant '())</code>.
+  If <code>&lt;tail-mapper&gt;</code> is omitted, it defaults to <code>(em-constant '())</code>.
   (Analogous to <code>unfold</code> from
   <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.)
 </p>
 
-<p id="ck-unfold-right"><code>(ck-unfold-right &lt;stop?&gt; &lt;mapper&gt; &lt;successor&gt;
+<p id="em-unfold-right"><code>(em-unfold-right &lt;stop?&gt; &lt;mapper&gt; &lt;successor&gt;
 &lt;seed&gt; &lt;tail&gt;)</code></p>
-<p id="ck-"><code>(ck-unfold-right &lt;stop?&gt; &lt;mapper&gt; &lt;successor&gt; &lt;seed&gt;)</code></p>
+<p id="em-"><code>(em-unfold-right &lt;stop?&gt; &lt;mapper&gt; &lt;successor&gt; &lt;seed&gt;)</code></p>
 
 <p>
   Expands into the expansion of <code>&lt;tail&gt;</code>
   if <code>(&lt;stop?&gt; &lt;seed&gt;)</code> does not expand
   into <code>#f</code>.  Expands into the expansion
-  of <code>(ck-unfold-right &lt;stop?&gt; &lt;mapper&gt;
-    &lt;successor&gt; (&lt;successor&gt; &lt;seed&gt;) (ck-cons
+  of <code>(em-unfold-right &lt;stop?&gt; &lt;mapper&gt;
+    &lt;successor&gt; (&lt;successor&gt; &lt;seed&gt;) (em-cons
     (&lt;mapper&gt; &lt;seed&gt;) &lt;tail&gt;))</code> otherwise.  If
   &lt;tail&gt; is omitted, it defaults to <code>'()</code>.
   (Analogous to <code>unfold-right</code> from
   <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.)
 </p>
 
-<p id="ck-map"><code>(ck-map &lt;proc&gt; &lt;list&gt; ...)</code></p>
+<p id="em-map"><code>(em-map &lt;proc&gt; &lt;list&gt; ...)</code></p>
 
 <p>
   Expands into the empty list if at least one
   the <code>&lt;list&gt;</code>s expands into the empty list.  Expands
-  into the expansion of <code>(ck-cons (&lt;proc&gt; &lt;head&gt; ...)
-    (ck-map &lt;proc&gt; &lt;tail&gt; ...))</code> if the <code>&lt;list&gt;</code>s expand into
+  into the expansion of <code>(em-cons (&lt;proc&gt; &lt;head&gt; ...)
+    (em-map &lt;proc&gt; &lt;tail&gt; ...))</code> if the <code>&lt;list&gt;</code>s expand into
   <code>(&lt;head&gt; . &lt;tail&gt;)</code>.
 </p>
 
-<p id="ck-append-map"><code>(ck-append-map &lt;proc&gt; &lt;list&gt; ...)</code></p>
+<p id="em-append-map"><code>(em-append-map &lt;proc&gt; &lt;list&gt; ...)</code></p>
 
 <p>
   Expands into the empty list if at least one
   the <code>&lt;list&gt;</code>s expands into the empty list.  Expands
-  into the expansion of <code>(ck-append (&lt;proc&gt; &lt;head&gt; ...)
-    (ck-map &lt;proc&gt; &lt;tail&gt; ...))</code> if the <code>&lt;list&gt;</code>s expand into
+  into the expansion of <code>(em-append (&lt;proc&gt; &lt;head&gt; ...)
+    (em-map &lt;proc&gt; &lt;tail&gt; ...))</code> if the <code>&lt;list&gt;</code>s expand into
   <code>(&lt;head&gt; . &lt;tail&gt;)</code>.
   (Analogous to <code>append-map</code> from
   <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.)
@@ -1220,21 +1187,21 @@ expands into a vector literal, and into <code>#f</code> otherwise.
 
 <h4>Filtering</h4>
 
-<p id="ck-filter"><code>(ck-filter &lt;pred&gt; &lt;list&gt; ...)</code></p>
+<p id="em-filter"><code>(em-filter &lt;pred&gt; &lt;list&gt; ...)</code></p>
 
 <p>Expands into a list consisting of those elements <em>element</em>;
   of the expansion of <code>&lt;list&gt;</code> in order, for
-  which <code>(ck-call &lt;pred&gt; <em>element</em>)</code> does not expand
+  which <code>(em-call &lt;pred&gt; <em>element</em>)</code> does not expand
   into <code>#f</code>.  It is an error if <code>&lt;list&gt;</code> does not expand into a list.
  (Analogous to <code>filter</code> from
   <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.)  
 </p>
 
-<p id="ck-remove"><code>(ck-remove &lt;pred&gt; &lt;list&gt; ...)</code></p>
+<p id="em-remove"><code>(em-remove &lt;pred&gt; &lt;list&gt; ...)</code></p>
 
 <p>Expands into a list consisting of those elements <em>element</em>;
   of the expansion of <code>&lt;list&gt;</code> in order for
-  which <code>(ck-call &lt;pred&gt; <em>element</em>)</code> expands
+  which <code>(em-call &lt;pred&gt; <em>element</em>)</code> expands
   into <code>#f</code>.  It is an error if <code>&lt;list&gt;</code> does not expand into a list.
  (Analogous to <code>remove</code> from
   <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.)
@@ -1242,11 +1209,11 @@ expands into a vector literal, and into <code>#f</code> otherwise.
 
 <h4>Searching</h4>
 
-<p id="ck-find"><code>(ck-find &lt;pred&gt; &lt;list&gt;)</code></p>
+<p id="em-find"><code>(em-find &lt;pred&gt; &lt;list&gt;)</code></p>
 
 <p>Expands into the first element <em>element</em> of the expansion
   of <code>&lt;list&gt;</code> for
-  which <code>(ck-call &lt;pred&gt; <em>element</em>)</code> does not expand
+  which <code>(em-call &lt;pred&gt; <em>element</em>)</code> does not expand
   into <code>#f</code>.  Expands into <code>#f</code> if there is no such <em>element</em>.
 
   It is an error if <code>&lt;list&gt;</code> does not expand into a list.
@@ -1255,11 +1222,11 @@ expands into a vector literal, and into <code>#f</code> otherwise.
   <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.)
 </p>
 
-<p id="ck-find-tail"><code>(ck-find-tail &lt;pred&gt; &lt;list&gt;)</code></p>
+<p id="em-find-tail"><code>(em-find-tail &lt;pred&gt; &lt;list&gt;)</code></p>
 
 <p>Expands into the first pair <em>pair</em> of the expansion
   of <code>&lt;list&gt;</code> for
-  which <code>(ck-call &lt;pred&gt; (ck-car <em>pair</em>))</code> does not expand
+  which <code>(em-call &lt;pred&gt; (em-car <em>pair</em>))</code> does not expand
   into <code>#f</code>.  Expands into <code>#f</code> if there is no such <em>pair</em>.
 
   It is an error if <code>&lt;list&gt;</code> does not expand into a list.
@@ -1268,11 +1235,11 @@ expands into a vector literal, and into <code>#f</code> otherwise.
   <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.)
 </p>
 
-<p id="ck-take-while"><code>(ck-take-while &lt;pred&gt; &lt;list&gt;)</code></p>
+<p id="em-take-while"><code>(em-take-while &lt;pred&gt; &lt;list&gt;)</code></p>
 
 <p>Expands into the longest initial sublist consisting of
   those <em>element</em>s of the expansion of <code>&lt;list&gt;</code>
-  for which <code>(ck-call &lt;pred&gt; <em>element</em>)</code> does not expand
+  for which <code>(em-call &lt;pred&gt; <em>element</em>)</code> does not expand
   into <code>#f</code>.
 
   It is an error if <code>&lt;list&gt;</code> does not expand into a list.
@@ -1281,11 +1248,11 @@ expands into a vector literal, and into <code>#f</code> otherwise.
   <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.)
 </p>
 
-<p id="ck-drop-while"><code>(ck-drop-while &lt;pred&gt; &lt;list&gt;)</code></p>
+<p id="em-drop-while"><code>(em-drop-while &lt;pred&gt; &lt;list&gt;)</code></p>
 
 <p>Expands into the first pair <em>pair</em> of the expansion
   of <code>&lt;list&gt;</code> for
-  which <code>(ck-call &lt;pred&gt; (ck-car <em>pair</em>))</code> expands
+  which <code>(em-call &lt;pred&gt; (em-car <em>pair</em>))</code> expands
   into <code>#f</code>.  Expands into <code>#f</code> if there is no such <em>pair</em>.
 
   It is an error if <code>&lt;list&gt;</code> does not expand into a list.
@@ -1294,73 +1261,73 @@ expands into a vector literal, and into <code>#f</code> otherwise.
   <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.)
 </p>
 
-<p id="ck-any"><code>(ck-any &lt;pred&gt; &lt;list&gt; ...)</code></p>
+<p id="em-any"><code>(em-any &lt;pred&gt; &lt;list&gt; ...)</code></p>
 
 <p>Expands into <code>#f</code> if at least one of
   the <code>&lt;list&gt;</code>s expands into the empty list.  Expands into the expansion of
-  <code>(ck-or (ck-call &lt;pred&gt; (ck-car &lt;list&gt;) ...) (ck-any
-  (ck-cdr &lt;list&gt;) ...))</code> otherwise.
+  <code>(em-or (em-call &lt;pred&gt; (em-car &lt;list&gt;) ...) (em-any
+  (em-cdr &lt;list&gt;) ...))</code> otherwise.
 
   It is an error if <code>&lt;list&gt;</code> does not expand into a list.
 
-  (Analogous to <code>ck-any</code> from
+  (Analogous to <code>em-any</code> from
   <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.)
 </p>
 
-<p id="ck-every"><code>(ck-every &lt;pred&gt; &lt;list&gt; ...)</code></p>
+<p id="em-every"><code>(em-every &lt;pred&gt; &lt;list&gt; ...)</code></p>
 
 <p>Expands into <code>#f</code> if at least one of
   the <code>&lt;list&gt;</code>s expands into the empty list.  Expands into the expansion of
-  <code>(ck-and (ck-call &lt;pred&gt; (ck-car &lt;list&gt;) ...) (ck-any &lt;pred&gt;
-    (ck-cdr &lt;list&gt;) ...))</code>  otherwise.
+  <code>(em-and (em-call &lt;pred&gt; (em-car &lt;list&gt;) ...) (em-any &lt;pred&gt;
+    (em-cdr &lt;list&gt;) ...))</code>  otherwise.
 
   It is an error if <code>&lt;list&gt;</code> does not expand into a list.
 
-  (Analogous to <code>ck-any</code> from
+  (Analogous to <code>em-any</code> from
   <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.)
 </p>
 
-<p id="ck-member"><code>(ck-member &lt;obj&gt; &lt;list&gt; &lt;compare&gt;)</code></p>
-<p><code>(ck-member &lt;obj&gt; &lt;list&gt;)</code></p>
+<p id="em-member"><code>(em-member &lt;obj&gt; &lt;list&gt; &lt;compare&gt;)</code></p>
+<p><code>(em-member &lt;obj&gt; &lt;list&gt;)</code></p>
 
-<p>Expands into the expansion of <code>(ck-find-tail (ck-cut &lt;compare&gt; &lt;obj&gt; <>)
+<p>Expands into the expansion of <code>(em-find-tail (em-cut &lt;compare&gt; &lt;obj&gt; <>)
       &lt;list&gt;)</code>.
 
-  If the input <code>&lt;compare&gt;</code> is omitted, it defaults to <code>ck-equal?</code>.
+  If the input <code>&lt;compare&gt;</code> is omitted, it defaults to <code>em-equal?</code>.
 </p>
 
 <h4>Association lists</h4>
 
-<p id="ck-assoc"><code>(ck-assoc &lt;key&gt; &lt;alist&gt; &lt;compare&gt;)</code></p>
-<p><code>(ck-assoc &lt;key&gt; &lt;alist&gt;)</code></p>
+<p id="em-assoc"><code>(em-assoc &lt;key&gt; &lt;alist&gt; &lt;compare&gt;)</code></p>
+<p><code>(em-assoc &lt;key&gt; &lt;alist&gt;)</code></p>
 
 <p>Expands into the first element <em>element</em> of the expansion
   of <code>&lt;alist&gt;</code> for
-  which <code>(ck-call &lt;compare&gt; &lt;key&gt; (ck-car <em>element</em>))</code> does not expand
+  which <code>(em-call &lt;compare&gt; &lt;key&gt; (em-car <em>element</em>))</code> does not expand
   into <code>#f</code>.  Expands into <code>#f</code> if there is no such <em>pair</em>.
 
-  If the input <code>&lt;compare&gt;</code> is omitted, it defaults to <code>ck-equal?</code>.
+  If the input <code>&lt;compare&gt;</code> is omitted, it defaults to <code>em-equal?</code>.
 
   It is an error if <code>&lt;alist&gt;</code> does not expand into an
   association list, a list of pairs.
 </p>
 
-<p id="ck-alist-delete"><code>(ck-alist-delete &lt;key&gt; &lt;alist&gt; &lt;compare&gt;)</code></p>
-<p><code>(ck-alist-delete &lt;key&gt; &lt;alist&gt;)</code></p>
+<p id="em-alist-delete"><code>(em-alist-delete &lt;key&gt; &lt;alist&gt; &lt;compare&gt;)</code></p>
+<p><code>(em-alist-delete &lt;key&gt; &lt;alist&gt;)</code></p>
 
 <p>
   Expands into an association list consisting of
   those <em>association</em>s of the expansion
-  of <code>&lt;alist&gt;</code> in order such that <code>(ck-call
-  &lt;compare&gt; &lt;key&gt; (ck-car <em>element</em>))</code>
+  of <code>&lt;alist&gt;</code> in order such that <code>(em-call
+  &lt;compare&gt; &lt;key&gt; (em-car <em>element</em>))</code>
   expands into <code>#f</code>.
 
-  If the input <code>&lt;compare&gt;</code> is omitted, it defaults to <code>ck-equal?</code>.
+  If the input <code>&lt;compare&gt;</code> is omitted, it defaults to <code>em-equal?</code>.
 
   It is an error if <code>&lt;alist&gt;</code> does not expand into an
   association list, a list of pairs.
 
-  (Analogous to <code>ck-alist-delete</code> from
+  (Analogous to <code>em-alist-delete</code> from
   <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.)
 </p>
 
@@ -1369,31 +1336,31 @@ expands into a vector literal, and into <code>#f</code> otherwise.
 The following operations are analogous to the set operations on lists
 from <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.
 
-<p id="ck-set<="><code>(ck-set&lt;= &lt;compare&gt; &lt;list&gt ...)</code></p>
+<p id="em-set<="><code>(em-set&lt;= &lt;compare&gt; &lt;list&gt ...)</code></p>
 
 <p>Expands into <code>#t</code> if the elements of the expansion of
   the <code>&lt;list&gt;</code>s form an increasing tower of sets,
   where <em>element<sub>1</sub></em> and <em>element<sub>2</sub></em>
   are considered equal
-  if <code>(ck-call &lt;compare&gt; <em>element<sub>1</sub></em> <em>element<sub>2</sub></em>)</code>
+  if <code>(em-call &lt;compare&gt; <em>element<sub>1</sub></em> <em>element<sub>2</sub></em>)</code>
   does not expand into <code>#f</code>.  It is an error if any of
   the <code>&lt;list&gt;</code>s do not expand into a list.
 </p>
 
-<p id="ck-set="><code>(ck-set= &lt;compare&gt; &lt;list&gt;<sub>1</sub> &lt;list&gt ...)</code></p>
+<p id="em-set="><code>(em-set= &lt;compare&gt; &lt;list&gt;<sub>1</sub> &lt;list&gt ...)</code></p>
 
 <p>Expands into <code>#t</code> if the elements of the expansion of
   the <code>&lt;list&gt;</code>s each form the same set as the
   elements of the expansion of <code>&lt;list&gt;<sub>1</sub></code>,
   where <em>element<sub>1</sub></em> and <em>element<sub>2</sub></em>
   are considered equal
-  if <code>(ck-call &lt;compare&gt; <em>element<sub>1</sub></em> <em>element<sub>2</sub></em>)</code>
+  if <code>(em-call &lt;compare&gt; <em>element<sub>1</sub></em> <em>element<sub>2</sub></em>)</code>
   does not expand into <code>#f</code>.  It is an error
   if <code>&lt;list&gt;<sub>1</sub></code> or any of
   the <code>&lt;list&gt;</code>s do not expand into a list.
 </p>
 
-<p id="ck-set-adjoin"><code>(ck-set-adjoin &lt;compare&gt;
+<p id="em-set-adjoin"><code>(em-set-adjoin &lt;compare&gt;
 &lt;list&gt; &lt;element&gt; ...)</code></p>
 
 <p>Expands into a list consisting of the elements of the expansion
@@ -1402,52 +1369,52 @@ from <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.
   that are not already elements of the list to which they are added.
   Here, <em>element<sub>1</sub></em> and <em>element<sub>2</sub></em>
   are considered equal
-  if <code>(ck-compare <em>element<sub>1</sub></em> <em>element<sub>2</sub></em>)</code>
+  if <code>(em-compare <em>element<sub>1</sub></em> <em>element<sub>2</sub></em>)</code>
   does not expand into <code>#f</code>.  It is an error
   if <code>&lt;list&gt;</code> does not expand into a list.
 </p>
 
-<p id="ck-set-union"><code>(ck-set-union &lt;compare&gt; &lt;list&gt; ...)</code></p>
+<p id="em-set-union"><code>(em-set-union &lt;compare&gt; &lt;list&gt; ...)</code></p>
 
 <p>Expands into a list constructured by adjoining (as
-  in <code>ck-set-adjoin</code>) the elements of the expansions of
+  in <code>em-set-adjoin</code>) the elements of the expansions of
   the <code>&lt;list&gt;</code>s to the empty list.
   It is an error
   if the <code>&lt;list&gt;</code>s do not expand into a list.
 </p>
 
-<p id="ck-set-intersection"><code>(ck-set-intersection
+<p id="em-set-intersection"><code>(em-set-intersection
 &lt;compare&gt; &lt;list&gt;<sub>1</sub> &lt;list&gt; ...)</code></p>
 
 <p>Expands into the sublist of the expansion
   of <code>&lt;list&gt;<sub>1</sub></code> (as
-  in <code>ck-filter</code>) consisting of those elements that also elements in the expansions of the
+  in <code>em-filter</code>) consisting of those elements that also elements in the expansions of the
   <code>&lt;list&gt;</code>s,
   where <em>element<sub>1</sub></em> and <em>element<sub>2</sub></em>
   are considered equal
-  if <code>(ck-call &lt;compare%gt; <em>element<sub>1</sub></em> <em>element<sub>2</sub></em>)</code>
+  if <code>(em-call &lt;compare%gt; <em>element<sub>1</sub></em> <em>element<sub>2</sub></em>)</code>
   does not expand into <code>#f</code>.  It is an error
   if <code>&lt;list&gt;<sub>1</sub></code> or any of
   the <code>&lt;list&gt;</code>s do not expand into a list.
 </p>
 
-<p id="ck-set-difference"><code>(ck-set-difference &lt;compare&gt;
+<p id="em-set-difference"><code>(em-set-difference &lt;compare&gt;
 &lt;list&gt;<sub>1</sub> &lt;list&gt; ...)</code></p>
 
 <p>Expands into the sublist of the expansion
   of <code>&lt;list&gt;<sub>1</sub></code> (as
-  in <code>ck-filter</code>) consisting of those elements that are not
+  in <code>em-filter</code>) consisting of those elements that are not
   elements in any of the expansions of the
   <code>&lt;list&gt;</code>s,
   where <em>element<sub>1</sub></em> and <em>element<sub>2</sub></em>
   are considered equal
-  if <code>(ck-call &lt;compare&gt; <em>element<sub>1</sub></em> <em>element<sub>2</sub></em>)</code>
+  if <code>(em-call &lt;compare&gt; <em>element<sub>1</sub></em> <em>element<sub>2</sub></em>)</code>
   does not expand into <code>#f</code>.  It is an error
   if <code>&lt;list&gt;<sub>1</sub></code> or any of
   the <code>&lt;list&gt;</code>s do not expand into a list.
 </p>
 
-<p id="ck-set-xor"><code>(ck-set-xor &lt;compare&gt; &lt;list&gt;<sub>1</sub> &lt;list&gt;<sub>2</sub>)</code></p>
+<p id="em-set-xor"><code>(em-set-xor &lt;compare&gt; &lt;list&gt;<sub>1</sub> &lt;list&gt;<sub>2</sub>)</code></p>
 
 <p>
   Expands into a list consisting of those elements of the expansion
@@ -1456,7 +1423,7 @@ from <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.
   elements of <code>&lt;list&gt;<sub>2</sub></code> that are not in
   the expansion of <code>&lt;list&gt;<sub>1</sub></code>,
   where <em>element<sub>1</sub></em> and <em>element<sub>2</sub></em>
-  are considered equal if <code>(ck-call
+  are considered equal if <code>(em-call
   &lt;compare&gt; <em>element<sub>1</sub></em> <em>element<sub>2</sub></em>)</code>
   does not expand into <code>#f</code>.  It is an error
   if <code>&lt;list&gt;<sub>1</sub></code> or
@@ -1466,13 +1433,13 @@ from <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.
 
 <h3 id="Vectorprocessing">Vector processing</h3>
 
-<p id="ck-vector"><code>(ck-vector &lt;element&gt; ...)</code></p>
+<p id="em-vector"><code>(em-vector &lt;element&gt; ...)</code></p>
 
 <p>
   Expands into a vector whose elements are the expansions of the <code>&lt;element&gt;</code>s.
 </p>
 
-<p id="ck-list->vector"><code>(ck-list-&gt;vector &lt;list&gt;)</code></p>
+<p id="em-list->vector"><code>(em-list-&gt;vector &lt;list&gt;)</code></p>
 
 <p>
   Expands into a vector whose elements are the elements of the
@@ -1480,7 +1447,7 @@ from <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.
   if <code>&lt;list&gt;</code> does not expand into a (proper) list.
 </p>
 
-<p id="ck-vector"><code>(ck-vector-&gt;list &lt;vector&gt;)</code></p>
+<p id="em-vector"><code>(em-vector-&gt;list &lt;vector&gt;)</code></p>
 
 <p>
   Expands into a list whose elements are the elements of the
@@ -1488,18 +1455,18 @@ from <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.
   if <code>&lt;vector&gt;</code> does not expand into a vector.
 </p>
 
-<p id="ck-vector-map"><code>(ck-vector-map &lt;proc&gt; &lt;vector&gt; ...)</code></p>
+<p id="em-vector-map"><code>(em-vector-map &lt;proc&gt; &lt;vector&gt; ...)</code></p>
 
 <p>
   Expands into the empty list if at least one
   the <code>&lt;vectors&gt;</code>s expands into the empty vector.
   Expands into the expansion of <code>`#(,(&lt;proc&gt; <em>head</em>
-  ...) ,@(ck-vector->list (ck-vector-map &lt;proc&gt; <em>tail</em> ...)))</code> if
+  ...) ,@(em-vector->list (em-vector-map &lt;proc&gt; <em>tail</em> ...)))</code> if
   the <code>&lt;vector&gt;</code>s expand into vectors of the form
   <code>`#u(,<em>head</em> ,@<em>tail</em>)</code>.
 </p>
 
-<p id="ck-vector-ref"><code>(ck-vector-ref &lt;vector&gt; &lt;k&gt;)</code></p>
+<p id="em-vector-ref"><code>(em-vector-ref &lt;vector&gt; &lt;k&gt;)</code></p>
 
 <p>
   Expands into the <em>k</em>th element of the expansion
@@ -1511,21 +1478,21 @@ from <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.
 
 <h3 id="Combinatorics">Combinatorics</h3>
 
-<p id="ck-0"><code>(ck-0)</code></p>
-<p id="ck-1"><code>(ck-1)</code></p>
-<p id="ck-2"><code>(ck-2)</code></p>
-<p id="ck-3"><code>(ck-3)</code></p>
-<p id="ck-4"><code>(ck-4)</code></p>
-<p id="ck-5"><code>(ck-5)</code></p>
-<p id="ck-6"><code>(ck-6)</code></p>
-<p id="ck-7"><code>(ck-7)</code></p>
-<p id="ck-8"><code>(ck-8)</code></p>
-<p id="ck-9"><code>(ck-9)</code></p>
-<p id="ck-10"><code>(ck-10)</code></p>
+<p id="em-0"><code>(em-0)</code></p>
+<p id="em-1"><code>(em-1)</code></p>
+<p id="em-2"><code>(em-2)</code></p>
+<p id="em-3"><code>(em-3)</code></p>
+<p id="em-4"><code>(em-4)</code></p>
+<p id="em-5"><code>(em-5)</code></p>
+<p id="em-6"><code>(em-6)</code></p>
+<p id="em-7"><code>(em-7)</code></p>
+<p id="em-8"><code>(em-8)</code></p>
+<p id="em-9"><code>(em-9)</code></p>
+<p id="em-10"><code>(em-10)</code></p>
 
 <p>Expands into a list of zero, one, two, ... pairwise different elements.</p>
 
-<p id="ck-="><code>(ck-= &lt;list&gt;<sub>1</sub> &lt;list&gt; ...)</code></p>
+<p id="em="><code>(em= &lt;list&gt;<sub>1</sub> &lt;list&gt; ...)</code></p>
 
 <p>
   Expands into <code>#t</code>
@@ -1537,7 +1504,7 @@ from <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.
   into lists.
 </p>
 
-<p id="ck-<"><code>(ck-&lt; &lt;list&gt; ...)</code></p>
+<p id="em<"><code>(em&lt; &lt;list&gt; ...)</code></p>
 
 <p>
   Expands into <code>#t</code>
@@ -1547,7 +1514,7 @@ from <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.
   do not expand into lists.
 </p>
 
-<p id="ck-<="><code>(ck-&lt;= &lt;list&gt; ...)</code></p>
+<p id="em<="><code>(em&lt;= &lt;list&gt; ...)</code></p>
 
 <p>
   Expands into <code>#t</code>
@@ -1557,7 +1524,7 @@ from <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.
   do not expand into lists.
 </p>
 
-<p id="ck->"><code>(ck-&gt; &lt;list&gt; ...)</code></p>
+<p id="em>"><code>(em&gt; &lt;list&gt; ...)</code></p>
 
 <p>
   Expands into <code>#t</code>
@@ -1567,7 +1534,7 @@ from <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.
   do not expand into lists.
 </p>
 
-<p id="ck->="><code>(ck-&gt;= &lt;list&gt; ...)</code></p>
+<p id="em>="><code>(em&gt;= &lt;list&gt; ...)</code></p>
 
 <p>
   Expands into <code>#t</code>
@@ -1577,35 +1544,35 @@ from <a href="http://srfi.schemers.org/srfi-1/srfi-1.html">SRFI 1</a>.
   do not expand into lists.
 </p>
 
-<p id="ck-zero?"><code>(ck-zero? &lt;list&gt;)</code></p>
+<p id="em-zero?"><code>(em-zero? &lt;list&gt;)</code></p>
 
 <p>Expands into <code>#t</code> if <code>&lt;list&gt;</code> expands
 into the empty list, and into <code>#f</code> otherwise.  It is an
   error if <code>&lt;list&gt;</code> does not expand into a list.
 </p>
 
-<p id="ck-even?"><code>(ck-even? &lt;list&gt;)</code></p>
+<p id="em-even?"><code>(em-even? &lt;list&gt;)</code></p>
 
 <p>Expands into <code>#t</code> if <code>&lt;list&gt;</code> expands
 into the list with an even number of elements, and into <code>#f</code> otherwise.  It is an
   error if <code>&lt;list&gt;</code> does not expand into a list.
 </p>
 
-<p id="ck-odd?"><code>(ck-odd? &lt;list&gt;)</code></p>
+<p id="em-odd?"><code>(em-odd? &lt;list&gt;)</code></p>
 
 <p>Expands into <code>#t</code> if <code>&lt;list&gt;</code> expands
 into the list with an odd number of elements, and into <code>#f</code> otherwise.  It is an
   error if <code>&lt;list&gt;</code> does not expand into a list.
 </p>
 
-<p id="ck-+"><code>(ck-+ &lt;list&gt; ...)</code></p>
+<p id="em+"><code>(em+ &lt;list&gt; ...)</code></p>
 
 <p>Expands into a list whose elements are the elements of the expansions of the
   <code>&lt;list&gt;</code>s in left-to-right order.  It is an
   error if the <code>&lt;list&gt;</code>s do not expand into a list.
 </p>
 
-<p id="ck--"><code>(ck-- &lt;list&gt;<sub>1</sub> &lt;list&gt; ...)</code></p>
+<p id="em-"><code>(em- &lt;list&gt;<sub>1</sub> &lt;list&gt; ...)</code></p>
 
 <p>Expands into a list whose elements are all but the last <em>k</em>
   elements of the expansion of the
@@ -1619,7 +1586,7 @@ into the list with an odd number of elements, and into <code>#f</code> otherwise
   in a list with less then <em>k</em> elements.
 </p>
 
-<p id="ck-*"><code>(ck-* &lt;list&gt; ...)</code></p>
+<p id="em*"><code>(em* &lt;list&gt; ...)</code></p>
 
 <p>Expands into a list whose elements are the elements of the
   cartesian product of the expansions of
@@ -1629,7 +1596,7 @@ into the list with an odd number of elements, and into <code>#f</code> otherwise
   error if the <code>&lt;list&gt;</code>s do not expand into lists.
 </p>
 
-<p id="ck-quotient"><code>(ck-quotient &lt;list&gt; &lt;k&gt;)</code></p>
+<p id="em-quotient"><code>(em-quotient &lt;list&gt; &lt;k&gt;)</code></p>
 
 <p>Expands into a list of each <em>k</em>th element in
   left-to-right order of the expansion
@@ -1640,7 +1607,7 @@ into the list with an odd number of elements, and into <code>#f</code> otherwise
   or <code>&lt;k&gt;</code> do not expand into lists.
 </p>
 
-<p id="ck-remainder"><code>(ck-remainder &lt;list&gt; &lt;k&gt;)</code></p>
+<p id="em-remainder"><code>(em-remainder &lt;list&gt; &lt;k&gt;)</code></p>
 
 <p>Expands into a smallest tail of the expansion
   of <code>&lt;list&gt;</code> such that the number of elements before the tail
@@ -1651,7 +1618,7 @@ into the list with an odd number of elements, and into <code>#f</code> otherwise
   or <code>&lt;k&gt;</code> do not expand into lists.
 </p>
 
-<p id="ck-fact"><code>(ck-fact &lt;list&gt;)</code></p>
+<p id="em-fact"><code>(em-fact &lt;list&gt;)</code></p>
 
 <p>Expands into a list of all permutations of the expansion of <code>&lt;list&gt;</code> in
   lexicographic left-to-right order.
@@ -1660,7 +1627,7 @@ into the list with an odd number of elements, and into <code>#f</code> otherwise
   does not expand into a list.
 </p>
 
-<p id="ck-binom"><code>(ck-binom &lt;list&gt; &lt;k&gt;)</code></p>
+<p id="em-binom"><code>(em-binom &lt;list&gt; &lt;k&gt;)</code></p>
 
 <p>Expands into a list of all <em>k</em>-element (ordered) sublists in
   lexicographic left-to-right order of the expansion

--- a/srfi/148.macros.scm
+++ b/srfi/148.macros.scm
@@ -23,808 +23,806 @@
 
 ;; General
 
-(define-syntax ck-constant
-  (ck-macro-transformer ::: ()
-    ((ck-constant 'const)
-     (ck-cut 'ck-constant-aux 'const <> ...))))
+(define-syntax em-constant
+  (em-syntax-rules ::: ()
+    ((em-constant 'const)
+     (em-cut 'em-constant-aux 'const <> ...))))
 
-(define-syntax ck-constant-aux
-  (ck-macro-transformer ()
-    ((ck-constant-aux 'const 'arg ...)
+(define-syntax em-constant-aux
+  (em-syntax-rules ()
+    ((em-constant-aux 'const 'arg ...)
      'const)))
 
-(define-syntax ck-append
-  (ck-macro-transformer ()
-    ((ck-append) ''())
-    ((ck-append 'l) 'l)
-    ((ck-append 'm ... '(a ...) 'l) (ck-append 'm ... '(a ... . l)))))
+(define-syntax em-append
+  (em-syntax-rules ()
+    ((em-append) ''())
+    ((em-append 'l) 'l)
+    ((em-append 'm ... '(a ...) 'l) (em-append 'm ... '(a ... . l)))))
 
-(define-syntax ck-list
-  (ck-macro-transformer ()
-    ((ck-list 'a ...) '(a ...))))
+(define-syntax em-list
+  (em-syntax-rules ()
+    ((em-list 'a ...) '(a ...))))
 
-(define-syntax ck-cons
-  (ck-macro-transformer ()
-    ((ck-cons 'h 't) '(h . t))))
+(define-syntax em-cons
+  (em-syntax-rules ()
+    ((em-cons 'h 't) '(h . t))))
 
-(define-syntax ck-cons*
-  (ck-macro-transformer ()
-    ((ck-cons* 'e ... 't) '(e ... . t))))
+(define-syntax em-cons*
+  (em-syntax-rules ()
+    ((em-cons* 'e ... 't) '(e ... . t))))
 
-(define-syntax ck-car
-  (ck-macro-transformer ()
-    ((ck-car '(h . t)) 'h)))
+(define-syntax em-car
+  (em-syntax-rules ()
+    ((em-car '(h . t)) 'h)))
 
-(define-syntax ck-cdr
-  (ck-macro-transformer ()
-    ((ck-cdr '(h . t)) 't)))
+(define-syntax em-cdr
+  (em-syntax-rules ()
+    ((em-cdr '(h . t)) 't)))
 
-(define-syntax ck-apply
-  (ck-macro-transformer ()
-    ((ck-apply 'keyword 'datum1 ... '(datum2 ...))
+(define-syntax em-apply
+  (em-syntax-rules ()
+    ((em-apply 'keyword 'datum1 ... '(datum2 ...))
      (keyword 'datum1 ... 'datum2 ...))))
 
-(define-syntax ck-call
-  (ck-macro-transformer ()
-    ((ck-apply 'keyword 'datum ...)
+(define-syntax em-call
+  (em-syntax-rules ()
+    ((em-apply 'keyword 'datum ...)
      (keyword 'datum ...))))
 
-(define-syntax ck-eval
-  (ck-macro-transformer ()
-    ((ck-eval '(keyword datum ...))
+(define-syntax em-eval
+  (em-syntax-rules ()
+    ((em-eval '(keyword datum ...))
      (keyword datum ...))))
 
-(define-syntax ck-error
-  (ck-macro-transformer ()
-    ((ck-error 'message 'arg ...)
-     (ck-suspend 'ck-error-aux 'message 'arg ...))))
+(define-syntax em-error
+  (em-syntax-rules ()
+    ((em-error 'message 'arg ...)
+     (em-suspend 'em-error-aux 'message 'arg ...))))
 
-(define-syntax ck-error-aux
+(define-syntax em-error-aux
   (syntax-rules ()
-    ((ck-error-aux s message arg ...)
+    ((em-error-aux s message arg ...)
      (syntax-error message arg ...))))
 
-(define-syntax ck-gensym
-  (ck-macro-transformer ()
-    ((ck-gensym) 'g)))
+(define-syntax em-gensym
+  (em-syntax-rules ()
+    ((em-gensym) 'g)))
 
-(define-syntax ck-generate-temporaries
-  (ck-macro-transformer ()
-    ((ck-generate-temporaries '()) '())
-    ((ck-generate-temporaries '(h . t))
-     (ck-cons (ck-gensym) (ck-generate-temporaries 't)))))
+(define-syntax em-generate-temporaries
+  (em-syntax-rules ()
+    ((em-generate-temporaries '()) '())
+    ((em-generate-temporaries '(h . t))
+     (em-cons (em-gensym) (em-generate-temporaries 't)))))
 
-(define-syntax ck-quote
-  (ck-macro-transformer ()
-    ((ck-quote 'x) ''x)))
+(define-syntax em-quote
+  (em-syntax-rules ()
+    ((em-quote 'x) ''x)))
 
 ;; Boolean logic
 
-(define-syntax ck-if
-  (ck-macro-transformer ()
-    ((ck-if '#f consequent alternate)
+(define-syntax em-if
+  (em-syntax-rules ()
+    ((em-if '#f consequent alternate)
      alternate)
-    ((ck-if 'test consequent alternate)
+    ((em-if 'test consequent alternate)
      consequent)))
 
-(define-syntax ck-not
-  (ck-macro-transformer ()
-    ((ck-not '#f)
+(define-syntax em-not
+  (em-syntax-rules ()
+    ((em-not '#f)
      '#t)
-    ((ck-not '_)
+    ((em-not '_)
      '#f)))
 
-(define-syntax ck-or
-  (ck-macro-transformer ()
-    ((ck-or)
+(define-syntax em-or
+  (em-syntax-rules ()
+    ((em-or)
      '#f)
-    ((ck-or 'x y ...)
-     (ck-if 'x 'x (ck-or y ...)))))
+    ((em-or 'x y ...)
+     (em-if 'x 'x (em-or y ...)))))
 
-(define-syntax ck-and
-  (ck-macro-transformer ()
-    ((ck-and 'x)
+(define-syntax em-and
+  (em-syntax-rules ()
+    ((em-and 'x)
      'x)
-    ((ck-and 'x y ...)
-     (ck-if 'x (ck-and y ...) '#f))))
+    ((em-and 'x y ...)
+     (em-if 'x (em-and y ...) '#f))))
 
-(define-syntax ck-null?
-  (ck-macro-transformer ()
-    ((ck-null? '())
+(define-syntax em-null?
+  (em-syntax-rules ()
+    ((em-null? '())
      '#t)
-    ((ck-null? '_)
+    ((em-null? '_)
      '#f)))
 
-(define-syntax ck-pair?
-  (ck-macro-transformer ()
-    ((ck-null? '(_ . _))
+(define-syntax em-pair?
+  (em-syntax-rules ()
+    ((em-null? '(_ . _))
      '#t)
-    ((ck-null? '_)
+    ((em-null? '_)
      '#f)))
 
-(define-syntax ck-list?
-  (ck-macro-transformer ()
-    ((ck-list? '())
+(define-syntax em-list?
+  (em-syntax-rules ()
+    ((em-list? '())
      '#t)
-    ((ck-list? '(_ . x))
-     (ck-list? 'x))
-    ((ck-list? '_)
+    ((em-list? '(_ . x))
+     (em-list? 'x))
+    ((em-list? '_)
      '#f)))
 
-(define-syntax ck-boolean?
-  (ck-macro-transformer ()
-    ((ck-boolean? '#f)
+(define-syntax em-boolean?
+  (em-syntax-rules ()
+    ((em-boolean? '#f)
      '#t)
-    ((ck-boolean? '#t)
+    ((em-boolean? '#t)
      '#t)
-    ((ck-boolean? '_)
+    ((em-boolean? '_)
      '#f)))
 
-(define-syntax ck-vector?
-  (ck-macro-transformer ()
-    ((ck-vector? '#(x ...))
+(define-syntax em-vector?
+  (em-syntax-rules ()
+    ((em-vector? '#(x ...))
      '#t)
-    ((ck-vector? '_)
+    ((em-vector? '_)
      '#f)))
 
-(define-syntax ck-symbol?
-  (ck-macro-transformer ()
-    ((ck-symbol? '(x . y)) '#f)
-    ((ck-symbol? '#(x ...)) '#f)
-    ((ck-symbol? 'x)
-     (ck-suspend 'ck-symbol?-aux 'x))))
+(define-syntax em-symbol?
+  (em-syntax-rules ()
+    ((em-symbol? '(x . y)) '#f)
+    ((em-symbol? '#(x ...)) '#f)
+    ((em-symbol? 'x)
+     (em-suspend 'em-symbol?-aux 'x))))
 
-(define-syntax ck-symbol?-aux
+(define-syntax em-symbol?-aux
   (syntax-rules ()
-    ((ck-symbol?-aux s x)
+    ((em-symbol?-aux s x)
      (begin
        (define-syntax test
 	 (syntax-rules ::: ()
-		       ((test x %s) (ck-resume %s '#t))
-		       ((test y %s) (ck-resume %s '#f))))
+		       ((test x %s) (em-resume %s '#t))
+		       ((test y %s) (em-resume %s '#f))))
        (test symbol s)))))
 
-(define-syntax ck-bound-identifier=?
-  (ck-macro-transformer ()
-    ((ck-bound-identifier=? 'id 'b)
-     (ck-suspend ck-bound-identifier=?-aux 'id 'b))))
+(define-syntax em-bound-identifier=?
+  (em-syntax-rules ()
+    ((em-bound-identifier=? 'id 'b)
+     (em-suspend em-bound-identifier=?-aux 'id 'b))))
 
-(define-syntax ck-bound-identifier=?-aux
+(define-syntax em-bound-identifier=?-aux
   (syntax-rules ()
-    ((ck-bound-identifier=?-aux s id b)
-     (bound-identifier=? id b (ck-resume s '#t) (ck-resume s '#f)))))
+    ((em-bound-identifier=?-aux s id b)
+     (bound-identifier=? id b (em-resume s '#t) (em-resume s '#f)))))
 
-(define-syntax ck-free-identifier=?
-  (ck-macro-transformer ()
-    ((ck-free-identifier=? 'id1 'id2)
-     (ck-suspend ck-free-identifier=?-aux 'id1 'id2))))
+(define-syntax em-free-identifier=?
+  (em-syntax-rules ()
+    ((em-free-identifier=? 'id1 'id2)
+     (em-suspend em-free-identifier=?-aux 'id1 'id2))))
 
-(define-syntax ck-free-identifier=?-aux
+(define-syntax em-free-identifier=?-aux
   (syntax-rules ()
-    ((ck-free-identifier=?-aux s id1 id2)
-     (free-identifier=? id1 id2 (ck-resume s '#t) (ck-resume s '#f)))))
+    ((em-free-identifier=?-aux s id1 id2)
+     (free-identifier=? id1 id2 (em-resume s '#t) (em-resume s '#f)))))
 
-(define-syntax ck-constant=?
-  (ck-macro-transformer ()
+(define-syntax em-constant=?
+  (em-syntax-rules ()
     ((ck= 'x 'y)
-     (ck-suspend ck-constant=?-aux 'x 'y))))
+     (em-suspend em-constant=?-aux 'x 'y))))
 
-(define-syntax ck-constant=?-aux
+(define-syntax em-constant=?-aux
   (syntax-rules ()
-    ((ck-constant=?-aux s x y)
+    ((em-constant=?-aux s x y)
      (begin
        (define-syntax test
 	 (syntax-rules ::: ()
-		       ((test x %s) (ck-resume %s '#t))
-		       ((test z %s) (ck-resume %s '#f))))
+		       ((test x %s) (em-resume %s '#t))
+		       ((test z %s) (em-resume %s '#f))))
        (test y s)))))
 
-(define-syntax ck-equal?
-  (ck-macro-transformer ()
-    ((ck-equal? '(x . y) '(u . v))
-     (ck-and (ck-equal? 'x 'u) (ck-equal? 'y 'v)))
-    ((ck-equal '#(x ...) '#(u ...))
-     (ck-and (ck-equal? 'x 'u) ...))
-    ((ck-equal '() '())
+(define-syntax em-equal?
+  (em-syntax-rules ()
+    ((em-equal? '(x . y) '(u . v))
+     (em-and (em-equal? 'x 'u) (em-equal? 'y 'v)))
+    ((em-equal '#(x ...) '#(u ...))
+     (em-and (em-equal? 'x 'u) ...))
+    ((em-equal '() '())
      '#t)
-    ((ck-equal 'x 'u)
-     (ck-if (ck-symbol? 'x)
-	    (ck-bound-identifier=? 'x 'u)
-	    (ck-constant=? 'x 'u)))
-    ((ck-equal '_ '_)
+    ((em-equal 'x 'u)
+     (em-if (em-symbol? 'x)
+	    (em-bound-identifier=? 'x 'u)
+	    (em-constant=? 'x 'u)))
+    ((em-equal '_ '_)
      '#f)))
 
 ;; List processing
 
-(define-syntax ck-caar
-  (ck-macro-transformer ()
-    ((ck-caar '((a . b) . c))
+(define-syntax em-caar
+  (em-syntax-rules ()
+    ((em-caar '((a . b) . c))
      'a)))
 
-(define-syntax ck-cadr
-  (ck-macro-transformer ()
-    ((ck-cadr '(a . (b . c)))
+(define-syntax em-cadr
+  (em-syntax-rules ()
+    ((em-cadr '(a . (b . c)))
      'b)))
 
-(define-syntax ck-cdar
-  (ck-macro-transformer ()
-    ((ck-cdar '((a . b) . c))
+(define-syntax em-cdar
+  (em-syntax-rules ()
+    ((em-cdar '((a . b) . c))
      'b)))
 
-(define-syntax ck-cddr
-  (ck-macro-transformer ()
-    ((ck-cddr '(a . (b . c)))
+(define-syntax em-cddr
+  (em-syntax-rules ()
+    ((em-cddr '(a . (b . c)))
      'c)))
 
-(define-syntax ck-first
-  (ck-macro-transformer ()
-    ((ck-first '(a . z))
+(define-syntax em-first
+  (em-syntax-rules ()
+    ((em-first '(a . z))
      'a)))
 
-(define-syntax ck-second
-  (ck-macro-transformer ()
-    ((ck-second '(a b . z))
+(define-syntax em-second
+  (em-syntax-rules ()
+    ((em-second '(a b . z))
      'b)))
 
-(define-syntax ck-third
-  (ck-macro-transformer ()
-    ((ck-third '(a b c . z))
+(define-syntax em-third
+  (em-syntax-rules ()
+    ((em-third '(a b c . z))
      'c)))
 
-(define-syntax ck-fourth
-  (ck-macro-transformer ()
-    ((ck-forth '(a b c d . z))
+(define-syntax em-fourth
+  (em-syntax-rules ()
+    ((em-forth '(a b c d . z))
      'd)))
 
-(define-syntax ck-fifth
-  (ck-macro-transformer ()
-    ((ck-fifth '(a b c d e . z))
+(define-syntax em-fifth
+  (em-syntax-rules ()
+    ((em-fifth '(a b c d e . z))
      'e)))
 
-(define-syntax ck-sixth
-  (ck-macro-transformer ()
-    ((ck-sixth '(a b c d e f . z))
+(define-syntax em-sixth
+  (em-syntax-rules ()
+    ((em-sixth '(a b c d e f . z))
      'f)))
 
-(define-syntax ck-seventh
-  (ck-macro-transformer ()
-    ((ck-seventh '(a b c d e f g . z))
+(define-syntax em-seventh
+  (em-syntax-rules ()
+    ((em-seventh '(a b c d e f g . z))
      'g)))
 
-(define-syntax ck-eighth
-  (ck-macro-transformer ()
-    ((ck-eighth '(a b c d e f g h . z))
+(define-syntax em-eighth
+  (em-syntax-rules ()
+    ((em-eighth '(a b c d e f g h . z))
      'h)))
 
-(define-syntax ck-ninth
-  (ck-macro-transformer ()
-    ((ck-ninth '(a b c d e f g h i . z))
+(define-syntax em-ninth
+  (em-syntax-rules ()
+    ((em-ninth '(a b c d e f g h i . z))
      'i)))
 
-(define-syntax ck-tenth
-  (ck-macro-transformer ()
-    ((ck-tenth '(a b c d e f g h i j . z))
+(define-syntax em-tenth
+  (em-syntax-rules ()
+    ((em-tenth '(a b c d e f g h i j . z))
      'j)))
 
-(define-syntax ck-make-list
-  (ck-macro-transformer ()
-    ((ck-make-list '() 'fill)
+(define-syntax em-make-list
+  (em-syntax-rules ()
+    ((em-make-list '() 'fill)
      '())
-    ((ck-make-list '(h . t) 'fill)
-     (ck-cons 'fill (ck-make-list 't 'fill)))))
+    ((em-make-list '(h . t) 'fill)
+     (em-cons 'fill (em-make-list 't 'fill)))))
 
-(define-syntax ck-reverse
-  (ck-macro-transformer ()
-    ((ck-reverse '())
+(define-syntax em-reverse
+  (em-syntax-rules ()
+    ((em-reverse '())
      '())
-    ((ck-reverse '(h ... t))
-     (ck-cons 't (ck-reverse '(h ...))))))
+    ((em-reverse '(h ... t))
+     (em-cons 't (em-reverse '(h ...))))))
 
-(define-syntax ck-list-tail
-  (ck-macro-transformer ()
-    ((ck-list-tail 'list '())
+(define-syntax em-list-tail
+  (em-syntax-rules ()
+    ((em-list-tail 'list '())
      'list)
-    ((ck-list-tail '(h . t) '(u . v))
-     (ck-list-tail 't 'v))))
+    ((em-list-tail '(h . t) '(u . v))
+     (em-list-tail 't 'v))))
 
-(define-syntax ck-drop
-  (ck-macro-transformer ()
-    ((ck-drop 'arg ...)
-     (ck-list-ref 'arg ...))))
+(define-syntax em-drop
+  (em-syntax-rules ()
+    ((em-drop 'arg ...)
+     (em-list-ref 'arg ...))))
 
-(define-syntax ck-list-ref
-  (ck-macro-transformer ()
-    ((ck-list-ref '(h . t) '())
+(define-syntax em-list-ref
+  (em-syntax-rules ()
+    ((em-list-ref '(h . t) '())
      'h)
-    ((ck-list-ref '(h . t) '(u . v))
-     (ck-list-ref 't 'v))))
+    ((em-list-ref '(h . t) '(u . v))
+     (em-list-ref 't 'v))))
 
-(define-syntax ck-take
-  (ck-macro-transformer ()
-    ((ck-take '_ '())
+(define-syntax em-take
+  (em-syntax-rules ()
+    ((em-take '_ '())
      '())
-    ((ck-take '(h . t) '(u . v))
-     (ck-cons 'h (ck-take 't 'v)))))
+    ((em-take '(h . t) '(u . v))
+     (em-cons 'h (em-take 't 'v)))))
 
-(define-syntax ck-take-right
-  (ck-macro-transformer ()
-    ((ck-take-right '(a ... . t) '())
+(define-syntax em-take-right
+  (em-syntax-rules ()
+    ((em-take-right '(a ... . t) '())
      't)
-    ((ck-take-right '(a ... b . t) '(u . v))     
-     `(,@(ck-take-right '(a ...) 'v) b . t)
+    ((em-take-right '(a ... b . t) '(u . v))     
+     `(,@(em-take-right '(a ...) 'v) b . t)
      )))
 
-(define-syntax ck-drop-right
-  (ck-macro-transformer ()
-    ((ck-drop-right '(a ... . t) '())
+(define-syntax em-drop-right
+  (em-syntax-rules ()
+    ((em-drop-right '(a ... . t) '())
      '(a ...))
-    ((ck-drop-right '(a ... b . t) '(u . v))
-     (ck-drop-right '(a ...) 'v))))
+    ((em-drop-right '(a ... b . t) '(u . v))
+     (em-drop-right '(a ...) 'v))))
 
-(define-syntax ck-last
-  (ck-macro-transformer ()
-    ((ck-last '(a ... b . t))
+(define-syntax em-last
+  (em-syntax-rules ()
+    ((em-last '(a ... b . t))
      'b)))
 
-(define-syntax ck-last-pair
-  (ck-macro-transformer ()
-    ((ck-last '(a ... b . t))
+(define-syntax em-last-pair
+  (em-syntax-rules ()
+    ((em-last '(a ... b . t))
      '(b . t))))
 
 ;; Folding, unfolding and mapping
 
-(define-syntax ck-fold
-  (ck-macro-transformer ()
-    ((ck-fold 'kons 'knil '(h . t) ...)
-     (ck-fold 'kons (kons 'h ... 'knil) 't ...))
-    ((ck-fold 'kons 'knil '_ ...)
+(define-syntax em-fold
+  (em-syntax-rules ()
+    ((em-fold 'kons 'knil '(h . t) ...)
+     (em-fold 'kons (kons 'h ... 'knil) 't ...))
+    ((em-fold 'kons 'knil '_ ...)
      'knil)))
 
-(define-syntax ck-fold-right
-  (ck-macro-transformer ()
-    ((ck-fold-right 'kons 'knil '(h . t) ...)
-     (kons 'h ... (ck-fold-right 'kons 'knil 't ...)))
-    ((ck-fold-right 'kons 'knil '_ ...)
+(define-syntax em-fold-right
+  (em-syntax-rules ()
+    ((em-fold-right 'kons 'knil '(h . t) ...)
+     (kons 'h ... (em-fold-right 'kons 'knil 't ...)))
+    ((em-fold-right 'kons 'knil '_ ...)
      'knil)))
 
-(define-syntax ck-unfold
-  (ck-macro-transformer ()
-    ((ck-unfold 'stop? 'mapper 'successor 'seed 'tail-mapper)
-     (ck-if (stop? 'seed)
+(define-syntax em-unfold
+  (em-syntax-rules ()
+    ((em-unfold 'stop? 'mapper 'successor 'seed 'tail-mapper)
+     (em-if (stop? 'seed)
 	    (tail-mapper 'seed)
-	    (ck-cons (mapper 'seed)
-		     (ck-unfold 'stop? 'mapper 'successor (successor 'seed) 'tail-mapper))))
-    ((ck-unfold 'stop? 'mapper 'successor 'seed)
-     (ck-unfold 'stop? 'mapper 'successor 'seed (ck-constant '())))))
+	    (em-cons (mapper 'seed)
+		     (em-unfold 'stop? 'mapper 'successor (successor 'seed) 'tail-mapper))))
+    ((em-unfold 'stop? 'mapper 'successor 'seed)
+     (em-unfold 'stop? 'mapper 'successor 'seed (em-constant '())))))
 
-(define-syntax ck-unfold-right
-  (ck-macro-transformer ()
-    ((ck-unfold-right 'stop? 'mapper 'successor 'seed 'tail)
-     (ck-if (stop? 'seed)
+(define-syntax em-unfold-right
+  (em-syntax-rules ()
+    ((em-unfold-right 'stop? 'mapper 'successor 'seed 'tail)
+     (em-if (stop? 'seed)
 	    'tail
-	    (ck-unfold-right 'stop?
+	    (em-unfold-right 'stop?
 			     'mapper
 			     'successor
 			     (successor 'seed)
-			     (ck-cons (mapper 'seed) 'tail))))
-    ((ck-unfold-right 'stop? 'mapper 'successor 'seed)
-     (ck-unfold-right 'stop? 'mapper 'successor 'seed '()))))
+			     (em-cons (mapper 'seed) 'tail))))
+    ((em-unfold-right 'stop? 'mapper 'successor 'seed)
+     (em-unfold-right 'stop? 'mapper 'successor 'seed '()))))
 
-(define-syntax ck-map
-  (ck-macro-transformer ()
-    ((ck-map 'proc '(h . t) ...)
-     (ck-cons (proc 'h ...) (ck-map 'proc 't ...)))
-    ((ck-map 'proc '_ ...)
+(define-syntax em-map
+  (em-syntax-rules ()
+    ((em-map 'proc '(h . t) ...)
+     (em-cons (proc 'h ...) (em-map 'proc 't ...)))
+    ((em-map 'proc '_ ...)
      '())))
 
-(define-syntax ck-append-map
-  (ck-macro-transformer ()
-    ((ck-append-map 'proc '(h . t) ...)
-     (ck-append (proc 'h ...) (ck-append-map 'proc 't ...)))
-    ((ck-append-map map 'proc '_)
+(define-syntax em-append-map
+  (em-syntax-rules ()
+    ((em-append-map 'proc '(h . t) ...)
+     (em-append (proc 'h ...) (em-append-map 'proc 't ...)))
+    ((em-append-map map 'proc '_)
      '())))
 
 ;; Filtering
 
-(define-syntax ck-filter
-  (ck-macro-transformer ()
-    ((ck-filter 'pred '())
+(define-syntax em-filter
+  (em-syntax-rules ()
+    ((em-filter 'pred '())
      '())
-    ((ck-filter 'pred '(h . t))
-     (ck-if (pred 'h)
-	    (ck-cons 'h (ck-filter 'pred 't))
-	    (ck-filter 'pred 't)))))
+    ((em-filter 'pred '(h . t))
+     (em-if (pred 'h)
+	    (em-cons 'h (em-filter 'pred 't))
+	    (em-filter 'pred 't)))))
 
-(define-syntax ck-remove
-  (ck-macro-transformer ()
-    ((ck-remove 'pred '())
+(define-syntax em-remove
+  (em-syntax-rules ()
+    ((em-remove 'pred '())
      '())
-    ((ck-remove 'pred '(h . t))
-     (ck-if (pred 'h)
-	    (ck-remove 'pred 't)
-	    (ck-cons 'h (ck-remove 'pred 't))))))
+    ((em-remove 'pred '(h . t))
+     (em-if (pred 'h)
+	    (em-remove 'pred 't)
+	    (em-cons 'h (em-remove 'pred 't))))))
 
 ;; Searching
 
-(define-syntax ck-find
-  (ck-macro-transformer ()
-    ((ck-find 'pred '())
+(define-syntax em-find
+  (em-syntax-rules ()
+    ((em-find 'pred '())
      '())
-    ((ck-find 'pred '(h . t))
-     (ck-if (pred 'h)
+    ((em-find 'pred '(h . t))
+     (em-if (pred 'h)
 	    'h
-	    (ck-find 'pred 't)))))
+	    (em-find 'pred 't)))))
 
-(define-syntax ck-find-tail
-  (ck-macro-transformer ()
-    ((ck-find-tail 'pred '())
+(define-syntax em-find-tail
+  (em-syntax-rules ()
+    ((em-find-tail 'pred '())
      '#f)
-    ((ck-find-tail 'pred '(h . t))
-     (ck-if (pred 'h)
+    ((em-find-tail 'pred '(h . t))
+     (em-if (pred 'h)
 	    '(h . t)
-	    (ck-find-tail 'pred 't)))))
+	    (em-find-tail 'pred 't)))))
 
-(define-syntax ck-take-while
-  (ck-macro-transformer ()
-    ((ck-take-while 'pred '())
+(define-syntax em-take-while
+  (em-syntax-rules ()
+    ((em-take-while 'pred '())
      '())
-    ((ck-take-while 'pred '(h . t))
-     (ck-if (pred 'h)
-	    (ck-cons 'h (ck-take-while 'pred 't))
+    ((em-take-while 'pred '(h . t))
+     (em-if (pred 'h)
+	    (em-cons 'h (em-take-while 'pred 't))
 	    '()))))
 
-(define-syntax ck-drop-while
-  (ck-macro-transformer ()
-    ((ck-drop-while 'pred '())
+(define-syntax em-drop-while
+  (em-syntax-rules ()
+    ((em-drop-while 'pred '())
      '())
-    ((ck-drop-while 'pred '(h . t))
-     (ck-if (pred 'h)
-	    (ck-drop-while 'pred 't)
+    ((em-drop-while 'pred '(h . t))
+     (em-if (pred 'h)
+	    (em-drop-while 'pred 't)
 	    '(h . t)))))
 
-(define-syntax ck-any
-  (ck-macro-transformer ()
-    ((ck-any 'pred '(h . t) ...)
-     (ck-or (pred 'h ...) (ck-any 'pred 't ...)))
-    ((ck-any 'pred '_ ...)
+(define-syntax em-any
+  (em-syntax-rules ()
+    ((em-any 'pred '(h . t) ...)
+     (em-or (pred 'h ...) (em-any 'pred 't ...)))
+    ((em-any 'pred '_ ...)
      '#f)))
 
-(define-syntax ck-every
-  (ck-macro-transformer ()
-    ((ck-every 'pred '() ...)
+(define-syntax em-every
+  (em-syntax-rules ()
+    ((em-every 'pred '() ...)
      '#t)
-    ((ck-every 'pred '(a b . x) ...)
-     (ck-and (pred 'a ...) (ck-every 'pred '(b . x) ...)))
-    ((ck-every 'pred '(h . t) ...)
+    ((em-every 'pred '(a b . x) ...)
+     (em-and (pred 'a ...) (em-every 'pred '(b . x) ...)))
+    ((em-every 'pred '(h . t) ...)
      (pred 'h ...))))
 
-(define-syntax ck-member
-  (ck-macro-transformer ()
-    ((ck-member 'obj 'list 'compare)
-     (ck-find-tail (ck-cut 'compare 'obj <>) 'list))
-    ((ck-member 'obj 'list)
-     (ck-member 'obj 'list 'ck-equal?))))
+(define-syntax em-member
+  (em-syntax-rules ()
+    ((em-member 'obj 'list 'compare)
+     (em-find-tail (em-cut 'compare 'obj <>) 'list))
+    ((em-member 'obj 'list)
+     (em-member 'obj 'list 'em-equal?))))
 
 ;; Association lists
 
-(define-syntax ck-assoc
-  (ck-macro-transformer ()
-    ((ck-assoc 'key '() 'compare)
+(define-syntax em-assoc
+  (em-syntax-rules ()
+    ((em-assoc 'key '() 'compare)
      '#f)
-    ((ck-assoc 'key '((k . v) . t) 'compare)
-     (ck-if (compare 'key 'k)
+    ((em-assoc 'key '((k . v) . t) 'compare)
+     (em-if (compare 'key 'k)
 	    '(k . v)
-	    (ck-assoc 'key 't 'compare)))
-    ((ck-assoc 'key 'alist)
-     (ck-assoc 'key 'alist 'ck-equal?))))
+	    (em-assoc 'key 't 'compare)))
+    ((em-assoc 'key 'alist)
+     (em-assoc 'key 'alist 'em-equal?))))
 
-(define-syntax ck-alist-delete
-  (ck-macro-transformer ()
-    ((ck-alist-delete 'key '() 'compare)
+(define-syntax em-alist-delete
+  (em-syntax-rules ()
+    ((em-alist-delete 'key '() 'compare)
      '())
-    ((ck-alist-delete 'key '((k . v) . t) 'compare)
-     (ck-if (compare 'key 'k)
-	    (ck-alist-delete 'key 't 'compare)
-	    (ck-cons '(k . v) (ck-alist-delete 'key 't 'compare))))
-    ((ck-alist-delete 'key 'alist)
-     (ck-alist-delete 'key 'alist 'ck-equal?))))
+    ((em-alist-delete 'key '((k . v) . t) 'compare)
+     (em-if (compare 'key 'k)
+	    (em-alist-delete 'key 't 'compare)
+	    (em-cons '(k . v) (em-alist-delete 'key 't 'compare))))
+    ((em-alist-delete 'key 'alist)
+     (em-alist-delete 'key 'alist 'em-equal?))))
 
 ;; Set operations
 
-(define-syntax ck-set<=
-  (ck-macro-transformer ()
-    ((ck-set<= 'compare '())
+(define-syntax em-set<=
+  (em-syntax-rules ()
+    ((em-set<= 'compare '())
      '#t)
-    ((ck-set<= 'compare 'list)
+    ((em-set<= 'compare 'list)
      '#t)
-    ((ck-set<= 'compare '() 'list)
+    ((em-set<= 'compare '() 'list)
      '#t)
-    ((ck-set<= 'compare '(h . t) 'list)
-     (ck-and (ck-member 'h 'list 'compare)
-	     (ck-set<= 'compare 't 'list)))
-    ((ck-set<= 'compare 'list1 'list2 'list ...)
-     (ck-and (ck-set<= 'compare 'list1 'list2)
-	     (ck-set<= 'compare 'list2 'list ...)))))
+    ((em-set<= 'compare '(h . t) 'list)
+     (em-and (em-member 'h 'list 'compare)
+	     (em-set<= 'compare 't 'list)))
+    ((em-set<= 'compare 'list1 'list2 'list ...)
+     (em-and (em-set<= 'compare 'list1 'list2)
+	     (em-set<= 'compare 'list2 'list ...)))))
 
-(define-syntax ck-set=
-  (ck-macro-transformer ()
-    ((ck-set= 'compare 'list)
+(define-syntax em-set=
+  (em-syntax-rules ()
+    ((em-set= 'compare 'list)
      '#t)
-    ((ck-set= 'compare 'list1 list2)
-     (ck-and (ck-set<= 'compare 'list1 'list2)
-	     (ck-set<= 'compare 'list2 'list1)))
-    ((ck-set= 'compare 'list1 'list2 'list ...)
-     (ck-and (ck-set= 'list1 'list2)
-	     (ck-set= 'list1 'list ...)))))
+    ((em-set= 'compare 'list1 list2)
+     (em-and (em-set<= 'compare 'list1 'list2)
+	     (em-set<= 'compare 'list2 'list1)))
+    ((em-set= 'compare 'list1 'list2 'list ...)
+     (em-and (em-set= 'list1 'list2)
+	     (em-set= 'list1 'list ...)))))
 
-(define-syntax ck-set-adjoin
-  (ck-macro-transformer ()
-    ((ck-set-adjoin 'compare 'list)
+(define-syntax em-set-adjoin
+  (em-syntax-rules ()
+    ((em-set-adjoin 'compare 'list)
      'list)
-    ((ck-set-adjoin 'compare 'list 'element1 'element2 ...)
-     (ck-if (ck-member 'element1 'list 'compare)
-	    (ck-set-adjoin 'compare 'list 'element2 ...)
-	    (ck-set-adjoin 'compare (ck-cons 'element1 'list) 'element2 ...)))))
+    ((em-set-adjoin 'compare 'list 'element1 'element2 ...)
+     (em-if (em-member 'element1 'list 'compare)
+	    (em-set-adjoin 'compare 'list 'element2 ...)
+	    (em-set-adjoin 'compare (em-cons 'element1 'list) 'element2 ...)))))
 
-(define-syntax ck-set-union
-  (ck-macro-transformer ()
-    ((ck-set-union 'compare 'list ...)
-     (ck-apply 'ck-set-adjoin 'compare '() (ck-append 'list ...)))))
+(define-syntax em-set-union
+  (em-syntax-rules ()
+    ((em-set-union 'compare 'list ...)
+     (em-apply 'em-set-adjoin 'compare '() (em-append 'list ...)))))
 
-(define-syntax ck-set-intersection
-  (ck-macro-transformer ()
-    ((ck-set-intersection 'compare 'list)
+(define-syntax em-set-intersection
+  (em-syntax-rules ()
+    ((em-set-intersection 'compare 'list)
      'list)
-    ((ck-set-intersection 'compare 'list1 'list2)
-     (ck-filter (ck-cut 'ck-member <> 'list2 'compare) 'list1))
-    ((ck-set-intersection 'compare 'list1 'list2 'list ...)
-     (ck-set-intersection 'compare (ck-set-intersection 'list1 'list2) 'list ...))))
+    ((em-set-intersection 'compare 'list1 'list2)
+     (em-filter (em-cut 'em-member <> 'list2 'compare) 'list1))
+    ((em-set-intersection 'compare 'list1 'list2 'list ...)
+     (em-set-intersection 'compare (em-set-intersection 'list1 'list2) 'list ...))))
 
-(define-syntax ck-set-difference
-  (ck-macro-transformer ()
-    ((ck-set-difference 'compare 'list)
+(define-syntax em-set-difference
+  (em-syntax-rules ()
+    ((em-set-difference 'compare 'list)
      'list)
-    ((ck-set-difference 'compare 'list1 'list2)
-     (ck-remove (ck-cut 'ck-member <> 'list2 'compare) 'list1))
-    ((ck-set-difference 'compare 'list1 'list2 'list ...)
-     (ck-set-difference 'compare (ck-set-difference 'list1 'list2) 'list ...))))
+    ((em-set-difference 'compare 'list1 'list2)
+     (em-remove (em-cut 'em-member <> 'list2 'compare) 'list1))
+    ((em-set-difference 'compare 'list1 'list2 'list ...)
+     (em-set-difference 'compare (em-set-difference 'list1 'list2) 'list ...))))
 
-(define-syntax ck-set-xor
-  (ck-macro-transformer ()
-    ((ck-set-xor 'compare 'list1 'list2)
-     (ck-set-union 'compare
-		   (ck-set-difference 'compare 'list1 'list2)
-		   (ck-set-difference 'compare 'list2 'list1)))))
+(define-syntax em-set-xor
+  (em-syntax-rules ()
+    ((em-set-xor 'compare 'list1 'list2)
+     (em-set-union 'compare
+		   (em-set-difference 'compare 'list1 'list2)
+		   (em-set-difference 'compare 'list2 'list1)))))
 
 ;; Vector processing
 
-(define-syntax ck-vector
-  (ck-macro-transformer ()
-    ((ck-vector 'element ...)
+(define-syntax em-vector
+  (em-syntax-rules ()
+    ((em-vector 'element ...)
      '#(element ...))))
 
-(define-syntax ck-list->vector
-  (ck-macro-transformer ()
-    ((ck-list->vector '(element ...))
+(define-syntax em-list->vector
+  (em-syntax-rules ()
+    ((em-list->vector '(element ...))
      '#(element ...))))
 
-(define-syntax ck-vector->list
-  (ck-macro-transformer ()
-    ((ck-list->vector '#(x ...))
+(define-syntax em-vector->list
+  (em-syntax-rules ()
+    ((em-list->vector '#(x ...))
      '(x ...))))
 
-(define-syntax ck-vector-map
-  (ck-macro-transformer ()
-    ((ck-vector-map 'proc 'vector ...)
-     (ck-list->vector (ck-map 'proc (ck-vector->list 'vector) ...)))))
+(define-syntax em-vector-map
+  (em-syntax-rules ()
+    ((em-vector-map 'proc 'vector ...)
+     (em-list->vector (em-map 'proc (em-vector->list 'vector) ...)))))
 
-(define-syntax ck-vector-ref
-  (ck-macro-transformer ()
-    ((ck-vector-ref '#(element1 element2 ...) '())
+(define-syntax em-vector-ref
+  (em-syntax-rules ()
+    ((em-vector-ref '#(element1 element2 ...) '())
      'element1)
-    ((ck-vector-ref '#(element1 element2 ...) '(h . t))
-     (ck-vector-ref '#(element2 ...) 't))))
+    ((em-vector-ref '#(element1 element2 ...) '(h . t))
+     (em-vector-ref '#(element2 ...) 't))))
 
 ;; Combinatorics
 
-(define-syntax ck-0
-  (ck-macro-transformer ()
-    ((ck-0)
+(define-syntax em-0
+  (em-syntax-rules ()
+    ((em-0)
      '())))
 
-(define-syntax ck-1
-  (ck-macro-transformer ()
-    ((ck-1)
+(define-syntax em-1
+  (em-syntax-rules ()
+    ((em-1)
      '(0))))
 
-(define-syntax ck-2
-  (ck-macro-transformer ()
-    ((ck-2)
+(define-syntax em-2
+  (em-syntax-rules ()
+    ((em-2)
      '(0 1))))
 
-(define-syntax ck-3
-  (ck-macro-transformer ()
-    ((ck-3)
+(define-syntax em-3
+  (em-syntax-rules ()
+    ((em-3)
      '(0 1 2))))
 
-(define-syntax ck-4
-  (ck-macro-transformer ()
-    ((ck-4)
+(define-syntax em-4
+  (em-syntax-rules ()
+    ((em-4)
      '(0 1 2 3))))
 
-(define-syntax ck-5
-  (ck-macro-transformer ()
-    ((ck-5)
+(define-syntax em-5
+  (em-syntax-rules ()
+    ((em-5)
      '(0 1 2 3 4))))
 
-(define-syntax ck-6
-  (ck-macro-transformer ()
-    ((ck-6)
+(define-syntax em-6
+  (em-syntax-rules ()
+    ((em-6)
      '(0 1 2 3 4 5))))
 
-(define-syntax ck-7
-  (ck-macro-transformer ()
-    ((ck-7)
+(define-syntax em-7
+  (em-syntax-rules ()
+    ((em-7)
      '(0 1 2 3 4 5 6))))
 
-(define-syntax ck-8
-  (ck-macro-transformer ()
-    ((ck-8)
+(define-syntax em-8
+  (em-syntax-rules ()
+    ((em-8)
      '(0 1 2 3 4 5 6 7))))
 
-(define-syntax ck-9
-  (ck-macro-transformer ()
-    ((ck-9)
+(define-syntax em-9
+  (em-syntax-rules ()
+    ((em-9)
      '(0 1 2 3 4 5 6 7 8))))
 
-(define-syntax ck-10
-  (ck-macro-transformer ()
-    ((ck-10)
+(define-syntax em-10
+  (em-syntax-rules ()
+    ((em-10)
      '(0 1 2 3 4 5 6 7 8 9))))
 
-(define-syntax ck-=
-  (ck-macro-transformer ()
-    ((ck-= '_)
+(define-syntax em=
+  (em-syntax-rules ()
+    ((em= '_)
      '#t)
-    ((ck-= '() '())
+    ((em= '() '())
      '#t)
-    ((ck-= '(h . t) '())
+    ((em= '(h . t) '())
      '#f)
-    ((ck-= '() '(h . t))
+    ((em= '() '(h . t))
      '#f)
-    ((ck-= '(h . t) '(u . v))
-     (ck-= 't 'v))
-    ((ck-= 'list1 'list2 'list ...)
-     (ck-and (ck-= 'list1 'list2)
-	     (ck-= 'list1 'list ...)))))
+    ((em= '(h . t) '(u . v))
+     (em= 't 'v))
+    ((em= 'list1 'list2 'list ...)
+     (em-and (em= 'list1 'list2)
+	     (em= 'list1 'list ...)))))
 
-(define-syntax ck-<
-  (ck-macro-transformer ()
-    ((ck-<)
+(define-syntax em<
+  (em-syntax-rules ()
+    ((em<)
      '#t)
-    ((ck-< 'list)
+    ((em< 'list)
      '#t)
-    ((ck-< '_ '())
+    ((em< '_ '())
      '#f)
-    ((ck-< '() '_)
+    ((em< '() '_)
      '#t)
-    ((ck-< '(t . h) '(u . v))
-     (ck-< 'h 'v))
-    ((ck-< 'list1 'list2 'list ...)
-     (ck-and (ck-< 'list1 'list2)
-	     (ck-< 'list2 'list ...)))))
+    ((em< '(t . h) '(u . v))
+     (em< 'h 'v))
+    ((em< 'list1 'list2 'list ...)
+     (em-and (em< 'list1 'list2)
+	     (em< 'list2 'list ...)))))
 
-(define-syntax ck-<=
-  (ck-macro-transformer ()
-    ((ck-<=)
+(define-syntax em<=
+  (em-syntax-rules ()
+    ((em<=)
      '#t)
-    ((ck-<= 'list)
+    ((em<= 'list)
      '#t)
-    ((ck-<= '() '_)
+    ((em<= '() '_)
      '#t)
-    ((ck-<= '_ '())
+    ((em<= '_ '())
      '#f)
-    ((ck-<= '(t . h) '(u . v))
-     (ck-<= 'h 'v))
-    ((ck-<= 'list1 'list2 'list ...)
-     (ck-and (ck-<= 'list1 'list2)
-	     (ck-<= 'list2 'list ...)))))
+    ((em<= '(t . h) '(u . v))
+     (em<= 'h 'v))
+    ((em<= 'list1 'list2 'list ...)
+     (em-and (em<= 'list1 'list2)
+	     (em<= 'list2 'list ...)))))
 
-(define-syntax ck->
-  (ck-macro-transformer ()
-    ((ck-> 'list ...)
-     (ck-apply 'ck-< (ck-reverse '(list ...))))))
+(define-syntax em>
+  (em-syntax-rules ()
+    ((em> 'list ...)
+     (em-apply 'em< (em-reverse '(list ...))))))
 
-(define-syntax ck->=
-  (ck-macro-transformer ()
-    ((ck->= 'list ...)
-     (ck-apply 'ck-<= (ck-reverse '(list ...))))))
+(define-syntax em>=
+  (em-syntax-rules ()
+    ((em>= 'list ...)
+     (em-apply 'em<= (em-reverse '(list ...))))))
 
-(define-syntax ck-zero? ck-null?)
+(define-syntax em-zero? em-null?)
 
-(define-syntax ck-even?
-  (ck-macro-transformer ()
-    ((ck-even? '())
+(define-syntax em-even?
+  (em-syntax-rules ()
+    ((em-even? '())
      '#t)
-    ((ck-even? '(a b . c))
-     (ck-even? 'c))
-    ((ck-even? '_)
+    ((em-even? '(a b . c))
+     (em-even? 'c))
+    ((em-even? '_)
      '#f)))
 
-(define-syntax ck-odd?
-  (ck-macro-transformer ()
-    ((ck-odd? 'list)
-     (ck-not (ck-even? 'list)))))
+(define-syntax em-odd?
+  (em-syntax-rules ()
+    ((em-odd? 'list)
+     (em-not (em-even? 'list)))))
 
-(define-syntax ck-+ ck-append)
+(define-syntax em+ em-append)
 
-(define-syntax ck--
-  (ck-macro-transformer ()
-    ((ck-- 'list)
+(define-syntax em-
+  (em-syntax-rules ()
+    ((em- 'list)
      'list)
-    ((ck-- 'list '())
+    ((em- 'list '())
      'list)
-    ((ck-- '(a ... b) '(u . v))
-     (ck-- '(a ...) 'v))
-    ((ck-- 'list1 'list2 'list ...)
-     (ck-- (ck-- 'list1 'list2) 'list ...))))
+    ((em- '(a ... b) '(u . v))
+     (em- '(a ...) 'v))
+    ((em- 'list1 'list2 'list ...)
+     (em- (em- 'list1 'list2) 'list ...))))
 
-(define-syntax ck-*
-  (ck-macro-transformer ()
-    ((ck-*)
+(define-syntax em*
+  (em-syntax-rules ()
+    ((em*)
      '(()))
-    ((ck-* 'list1 'list2 ...)
-     (ck-*-aux 'list1 (ck-* 'list2 ...)))))
+    ((em* 'list1 'list2 ...)
+     (em*-aux 'list1 (em* 'list2 ...)))))
 
-(define-syntax ck-*-aux
-  (ck-macro-transformer ()
-    ((ck-*-aux '(x ...) 'list)
-     (ck-append (ck-map (ck-cut 'ck-cons 'x <>) 'list) ...))
-    ((ck-*-aux arg ...)
-     (ck-error '"???" 'arg ...))))
+(define-syntax em*-aux
+  (em-syntax-rules ()
+    ((em*-aux '(x ...) 'list)
+     (em-append (em-map (em-cut 'em-cons 'x <>) 'list) ...))))
 
-(define-syntax ck-quotient
-  (ck-macro-transformer ()
-    ((ck-quotient 'list 'k)
-     (ck-if (ck->= 'list 'k)
-	    (ck-cons (ck-car 'list)
-		     (ck-quotient (ck-list-tail 'list 'k) 'k))
+(define-syntax em-quotient
+  (em-syntax-rules ()
+    ((em-quotient 'list 'k)
+     (em-if (em>= 'list 'k)
+	    (em-cons (em-car 'list)
+		     (em-quotient (em-list-tail 'list 'k) 'k))
 	    '()))))
 
-(define-syntax ck-remainder
-  (ck-macro-transformer ()
-    ((ck-quotient 'list 'k)
-     (ck-if (ck->= 'list 'k)
-	    (ck-remainder (ck-list-tail 'list 'k) 'k)
+(define-syntax em-remainder
+  (em-syntax-rules ()
+    ((em-quotient 'list 'k)
+     (em-if (em>= 'list 'k)
+	    (em-remainder (em-list-tail 'list 'k) 'k)
 	    'list))))
 
-(define-syntax ck-binom
-  (ck-macro-transformer ()
-    ((ck-binom 'list '())
+(define-syntax em-binom
+  (em-syntax-rules ()
+    ((em-binom 'list '())
      '(()))
-    ((ck-binom '() '(h . t))
+    ((em-binom '() '(h . t))
      '())
-    ((ck-binom '(u . v) '(h . t))
-     (ck-append (ck-map (ck-cut 'ck-cons u <>) (ck-binom 'v 't))
-		(ck-binom 'v '(h . t))))))
+    ((em-binom '(u . v) '(h . t))
+     (em-append (em-map (em-cut 'em-cons u <>) (em-binom 'v 't))
+		(em-binom 'v '(h . t))))))
 
-(define-syntax ck-fact
-  (ck-macro-transformer ()
-    ((ck-fact '())
+(define-syntax em-fact
+  (em-syntax-rules ()
+    ((em-fact '())
      '(()))
-    ((ck-fact 'list)
-     (ck-append-map 'ck-fact-cons*
-		    'list (ck-map 'ck-fact (ck-fact-del 'list))))))
+    ((em-fact 'list)
+     (em-append-map 'em-fact-cons*
+		    'list (em-map 'em-fact (em-fact-del 'list))))))
 
-(define-syntax ck-fact-del
-  (ck-macro-transformer ()
-    ((ck-fact-del '())
+(define-syntax em-fact-del
+  (em-syntax-rules ()
+    ((em-fact-del '())
      '())
-    ((ck-fact-del '(h . t))
-     `(t ,@(ck-map (ck-cut 'ck-cons 'h <>) (ck-fact-del 't))))))
+    ((em-fact-del '(h . t))
+     `(t ,@(em-map (em-cut 'em-cons 'h <>) (em-fact-del 't))))))
 
-(define-syntax ck-fact-cons*
-  (ck-macro-transformer ()
-    ((ck-fact-cons* 'a '((l ...) ...))
+(define-syntax em-fact-cons*
+  (em-syntax-rules ()
+    ((em-fact-cons* 'a '((l ...) ...))
      '((a l ...) ...))))
  

--- a/srfi/148.scm
+++ b/srfi/148.scm
@@ -115,8 +115,9 @@
 
     ((ck-macro-transformer-aux1 a c e* e l* (((_ p ...) (i => v) w ... t) . r*) (r1 ...) (r2 ...))
      (ck-macro-transformer-aux1 a c e* e l* r*
-				(r1 ... ((_ p ...) (a i 'p ...)))
-				(r2 ... ((_ v 'p ...) w ... t))))
+				(r1 ... ((_ p ...) (a i '(p ...))))
+				(r2 ... ((_ v '(p ...)) w ... t))))
+
     ((ck-macro-transformer-aux1 a c e* e l* () r1* r2*)
      (begin (define-syntax a
 	      (ck-macro-transformer-aux1 c e* e l* r2*))

--- a/srfi/148.sld
+++ b/srfi/148.sld
@@ -21,140 +21,140 @@
 ;; SOFTWARE.
 
 (define-library (srfi 148)
-  (export ck-macro-transformer
+  (export em-syntax-rules
 
 	  ;; General
-	  ck-expression
-	  ck-cut
-	  ck-cute
-	  ck-constant
-	  ck-quote
-	  ck-eval
-	  ck-apply
-	  ck-call
-	  ck-error
-	  ck-gensym
-	  ck-generate-temporaries
+	  em
+	  em-cut
+	  em-cute
+	  em-constant
+	  em-quote
+	  em-eval
+	  em-apply
+	  em-call
+	  em-error
+	  em-gensym
+	  em-generate-temporaries
 
 	  ;; Boolean logic
-	  ck-if
-	  ck-not
-	  ck-or
-	  ck-and
-	  ck-null?
-	  ck-pair?
-	  ck-list?
-	  ck-boolean?
-	  ck-vector?
-	  ck-symbol?
-	  ck-bound-identifier=?
-	  ck-free-identifier=?
-	  ck-equal?
+	  em-if
+	  em-not
+	  em-or
+	  em-and
+	  em-null?
+	  em-pair?
+	  em-list?
+	  em-boolean?
+	  em-vector?
+	  em-symbol?
+	  em-bound-identifier=?
+	  em-free-identifier=?
+	  em-equal?
 	  
 	  ;; Constructors
-	  ck-cons
-	  ck-cons*
-	  ck-list
-	  ck-make-list
+	  em-cons
+	  em-cons*
+	  em-list
+	  em-make-list
 	  
 	  ;; Selectors
-	  ck-car
-	  ck-cdr
-	  ck-caar
-	  ck-cadr
-	  ck-cdar
-	  ck-cddr
-	  ck-first
-	  ck-second
-	  ck-third
-	  ck-fourth
-	  ck-fifth
-	  ck-sixth
-	  ck-seventh
-	  ck-eighth
-	  ck-ninth
-	  ck-tenth
-	  ck-list-tail
-	  ck-list-ref
-	  ck-take
-	  ck-drop
-	  ck-take-right
-	  ck-drop-right
-	  ck-last
-	  ck-last-pair
+	  em-car
+	  em-cdr
+	  em-caar
+	  em-cadr
+	  em-cdar
+	  em-cddr
+	  em-first
+	  em-second
+	  em-third
+	  em-fourth
+	  em-fifth
+	  em-sixth
+	  em-seventh
+	  em-eighth
+	  em-ninth
+	  em-tenth
+	  em-list-tail
+	  em-list-ref
+	  em-take
+	  em-drop
+	  em-take-right
+	  em-drop-right
+	  em-last
+	  em-last-pair
 
 	  ;; Miscellaneous
-	  ck-append
-	  ck-reverse
+	  em-append
+	  em-reverse
 
 	  ;; Folding, unfolding, and mapping
-	  ck-fold
-	  ck-fold-right
-	  ck-unfold
-	  ck-unfold-right
-	  ck-map
-	  ck-append-map
+	  em-fold
+	  em-fold-right
+	  em-unfold
+	  em-unfold-right
+	  em-map
+	  em-append-map
 	  
 	  ;; Filtering
-	  ck-filter
-	  ck-remove
+	  em-filter
+	  em-remove
 	  
 	  ;; Searching
-	  ck-find
-	  ck-find-tail
-	  ck-take-while
-	  ck-drop-while
-	  ck-any
-	  ck-every
-	  ck-member
+	  em-find
+	  em-find-tail
+	  em-take-while
+	  em-drop-while
+	  em-any
+	  em-every
+	  em-member
 	  
 	  ;; Association lists
-	  ck-assoc
-	  ck-alist-delete
+	  em-assoc
+	  em-alist-delete
 
 	  ;; Set operationse
-	  ck-set<=
-	  ck-set=
-	  ck-set-adjoin
-	  ck-set-union
-	  ck-set-intersection
-	  ck-set-difference
-	  ck-set-xor
+	  em-set<=
+	  em-set=
+	  em-set-adjoin
+	  em-set-union
+	  em-set-intersection
+	  em-set-difference
+	  em-set-xor
 
 	  ;; Vector processing
-	  ck-vector
-	  ck-list->vector
-	  ck-vector->list
-	  ck-vector-map
-	  ck-vector-ref
+	  em-vector
+	  em-list->vector
+	  em-vector->list
+	  em-vector-map
+	  em-vector-ref
 	  
 	  ;; Combinatorics
-	  ck-0
-	  ck-1
-	  ck-2
-	  ck-3
-	  ck-4
-	  ck-5
-	  ck-6
-	  ck-7
-	  ck-8
-	  ck-9
-	  ck-10
-	  ck-=
-	  ck-<
-	  ck-<=
-	  ck->
-	  ck->=
-	  ck-zero?
-	  ck-even?
-	  ck-odd?
-	  ck-+
-	  ck--
-	  ck-*
-	  ck-quotient
-	  ck-remainder
-	  ck-fact
-	  ck-binom
+	  em-0
+	  em-1
+	  em-2
+	  em-3
+	  em-4
+	  em-5
+	  em-6
+	  em-7
+	  em-8
+	  em-9
+	  em-10
+	  em=
+	  em<
+	  em<=
+	  em>
+	  em>=
+	  em-zero?
+	  em-even?
+	  em-odd?
+	  em+
+	  em-
+	  em*
+	  em-quotient
+	  em-remainder
+	  em-fact
+	  em-binom
 	  
 	  ;; Auxiliary syntax
 	  =>
@@ -166,7 +166,7 @@
 	   "148.macros.scm"))
 
 ;; Local Variables:
-;; eval: (put 'ck-macro-transformer 'scheme-indent-function 'defun)
+;; eval: (put 'em-syntax-rules 'scheme-indent-function 'defun)
 ;; eval: (font-lock-add-keywords 'scheme-mode
-;;                               '(("(\\(ck-macro-transformer\\)\\>" 1 font-lock-keyword-face)))
+;;                               '(("(\\(em-syntax-rules\\)\\>" 1 font-lock-keyword-face)))
 ;; End:

--- a/srfi/148/test.sld
+++ b/srfi/148/test.sld
@@ -538,201 +538,201 @@
 	    (ck-expression (ck-= (ck-set-difference 'ck-equal? '(1 2 3) '(3 4 5)) (ck-2))))
 
 	  (test-assert "ck-set-xor"
-	    (ck-expression (ck-= (ck-set-xor 'ck-equal? '(1 2 3) '(3 4 5)) (ck-4)))))
+	    (ck-expression (ck-= (ck-set-xor 'ck-equal? '(1 2 3) '(3 4 5)) (ck-4))))))
+
+      ;; Vector processing
+      (test-group "Vector processing"
+		  
+		  (test-equal "ck-vector"
+		    #(10 20 30)
+		    (ck-expression (ck-quote (ck-vector 10 20 30))))
+
+		  (test-equal "ck-list->vector"
+		    #(10 20 30)
+		    (ck-expression (ck-quote (ck-list->vector '(10 20 30)))))
+		  
+		  (test-equal "ck-vector->list"
+		    '(10 20 30)
+		    (ck-expression (ck-quote (ck-vector->list #(10 20 30)))))
+
+		  (test-equal "ck-vector-map"
+		    '#((1 . a) (2 . b) (3 . c))
+		    (ck-expression (ck-quote (ck-vector-map 'ck-cons '#(1 2 3) '#(a b c d)))))
+		  
+		  (test-equal "ck-vector-ref"
+		    20
+		    (ck-expression (ck-quote (ck-vector-ref #(10 20 30) (ck-1))))))
 	
-	;; Vector processing
-	(test-group "Vector processing"
+      (test-group "Combinatorics"
 
-	  (test-equal "ck-vector"
-	    #(10 20 30)
-	    (ck-expression (ck-quote (ck-vector 10 20 30))))
+		  (test-equal "ck-0"
+		    #t
+		    (ck-expression (ck-= '() (ck-0))))
 
-	  (test-equal "ck-list->vector"
-	    #(10 20 30)
-	    (ck-expression (ck-quote (ck-list->vector '(10 20 30)))))
-	  
-	  (test-equal "ck-vector->list"
-	    '(10 20 30)
-	    (ck-expression (ck-quote (ck-vector->list #(10 20 30)))))
+		  (test-equal "ck-1"
+		    #t
+		    (ck-expression (ck-= '(0) (ck-1))))
 
-	  (test-equal "ck-vector-map"
-	    '#((1 . a) (2 . b) (3 . c))
-	    (ck-expression (ck-quote (ck-vector-map 'ck-cons '#(1 2 3) '#(a b c d)))))
-	  
-	  (test-equal "ck-vector-ref"
-	    20
-	    (ck-expression (ck-quote (ck-vector-ref #(10 20 30) (ck-1))))))
-	
-	(test-group "Combinatorics"
+		  (test-equal "ck-2"
+		    #t
+		    (ck-expression (ck-= '(0 1) (ck-2))))
 
-	  (test-equal "ck-0"
-	    #t
-	    (ck-expression (ck-= '() (ck-0))))
+		  (test-equal "ck-3"
+		    #t
+		    (ck-expression (ck-= '(0 1 2) (ck-3))))
 
-	  (test-equal "ck-1"
-	    #t
-	    (ck-expression (ck-= '(0) (ck-1))))
+		  (test-equal "ck-4"
+		    #t
+		    (ck-expression (ck-= '(0 1 2 3) (ck-4))))
 
-	  (test-equal "ck-2"
-	    #t
-	    (ck-expression (ck-= '(0 1) (ck-2))))
+		  (test-equal "ck-5"
+		    #t
+		    (ck-expression (ck-= '(0 1 2 3 4) (ck-5))))
 
-	  (test-equal "ck-3"
-	    #t
-	    (ck-expression (ck-= '(0 1 2) (ck-3))))
+		  (test-equal "ck-6"
+		    #t
+		    (ck-expression (ck-= '(0 1 2 3 4 5) (ck-6))))
 
-	  (test-equal "ck-4"
-	    #t
-	    (ck-expression (ck-= '(0 1 2 3) (ck-4))))
+		  (test-equal "ck-7"
+		    #t
+		    (ck-expression (ck-= '(0 1 2 3 4 5 6) (ck-7))))
 
-	  (test-equal "ck-5"
-	    #t
-	    (ck-expression (ck-= '(0 1 2 3 4) (ck-5))))
+		  (test-equal "ck-8"
+		    #t
+		    (ck-expression (ck-= '(0 1 2 3 4 5 6 7) (ck-8))))
 
-	  (test-equal "ck-6"
-	    #t
-	    (ck-expression (ck-= '(0 1 2 3 4 5) (ck-6))))
+		  (test-equal "ck-9"
+		    #t
+		    (ck-expression (ck-= '(0 1 2 3 4 5 6 7 8) (ck-9))))
+		  
+		  (test-equal "ck-10"
+		    #t
+		    (ck-expression (ck-= '(0 1 2 3 4 5 6 7 8 9) (ck-10))))
 
-	  (test-equal "ck-7"
-	    #t
-	    (ck-expression (ck-= '(0 1 2 3 4 5 6) (ck-7))))
+		  (test-assert "ck-=: true"
+		    (ck-expression (ck-quote (ck-= '(1 2 3) '(a b c) '(foo bar baz)))))
+		  
+		  (test-assert "ck-=: false"
+		    (ck-expression (ck-quote (ck-not (ck-= '(1 2 3) '(a b c d) '(foo bar baz))))))
 
-	  (test-equal "ck-8"
-	    #t
-	    (ck-expression (ck-= '(0 1 2 3 4 5 6 7) (ck-8))))
+		  (test-assert "ck-<: true"
+		    (ck-expression (ck-quote (ck-< '(1) '(a b) '(foo bar baz)))))
+		  
+		  (test-assert "ck-<: false"
+		    (ck-expression (ck-quote (ck-not (ck-< '(1 2) '(a b c) '(foo bar baz))))))
 
-	  (test-equal "ck-9"
-	    #t
-	    (ck-expression (ck-= '(0 1 2 3 4 5 6 7 8) (ck-9))))
-	  
-	  (test-equal "ck-10"
-	    #t
-	    (ck-expression (ck-= '(0 1 2 3 4 5 6 7 8 9) (ck-10))))
+		  (test-assert "ck-<=: true"
+		    (ck-expression (ck-quote (ck-<= '(1 2) '(a b c) '(foo bar baz)))))
+		  
+		  (test-assert "ck-<=: false"
+		    (ck-expression (ck-quote (ck-not (ck-<= '(1 2 3) '(a b c d) '(foo bar baz))))))
 
-	  (test-assert "ck-=: true"
-	    (ck-expression (ck-quote (ck-= '(1 2 3) '(a b c) '(foo bar baz)))))
-	  
-	  (test-assert "ck-=: false"
-	    (ck-expression (ck-quote (ck-not (ck-= '(1 2 3) '(a b c d) '(foo bar baz))))))
+		  (test-assert "ck->: true"
+		    (ck-expression (ck-quote (ck-> '(1 2 3 4 5) '(a b c d) '(foo bar baz)))))
+		  
+		  (test-assert "ck->: false"
+		    (ck-expression (ck-quote (ck-not (ck-> '(1 2 3) '(a b c d) '(foo bar baz))))))
 
-	  (test-assert "ck-<: true"
-	    (ck-expression (ck-quote (ck-< '(1) '(a b) '(foo bar baz)))))
-	  
-	  (test-assert "ck-<: false"
-	    (ck-expression (ck-quote (ck-not (ck-< '(1 2) '(a b c) '(foo bar baz))))))
+		  (test-assert "ck->=: true"
+		    (ck-expression (ck-quote (ck->= '(1 2 3 4) '(a b c d) '(foo bar baz)))))
+		  
+		  (test-assert "ck->=: false"
+		    (ck-expression (ck-quote (ck-not (ck->= '(1 2 3) '(a b c d) '(foo bar baz))))))
 
-	  (test-assert "ck-<=: true"
-	    (ck-expression (ck-quote (ck-<= '(1 2) '(a b c) '(foo bar baz)))))
-	  
-	  (test-assert "ck-<=: false"
-	    (ck-expression (ck-quote (ck-not (ck-<= '(1 2 3) '(a b c d) '(foo bar baz))))))
+		  (test-assert "ck-zero?: true"
+		    (ck-expression (ck-quote (ck-zero? (ck-0)))))
 
-	  (test-assert "ck->: true"
-	    (ck-expression (ck-quote (ck-> '(1 2 3 4 5) '(a b c d) '(foo bar baz)))))
-	  
-	  (test-assert "ck->: false"
-	    (ck-expression (ck-quote (ck-not (ck-> '(1 2 3) '(a b c d) '(foo bar baz))))))
+		  (test-assert "ck-zero?: false"
+		    (ck-expression (ck-quote (ck-not (ck-zero? (ck-1))))))
+		  
+		  (test-assert "ck-even?: true"
+		    (ck-expression (ck-quote (ck-even? (ck-4)))))
+		  
+		  (test-assert "ck-even?: false"
+		    (ck-expression (ck-quote (ck-not (ck-even? (ck-3))))))
+		  
+		  (test-assert "ck-odd?: true"
+		    (ck-expression (ck-quote (ck-odd? (ck-1)))))
+		  
+		  (test-assert "ck-odd?: false"
+		    (ck-expression (ck-quote (ck-not (ck-odd? (ck-2))))))
 
-	  (test-assert "ck->=: true"
-	    (ck-expression (ck-quote (ck->= '(1 2 3 4) '(a b c d) '(foo bar baz)))))
-	  
-	  (test-assert "ck->=: false"
-	    (ck-expression (ck-quote (ck-not (ck->= '(1 2 3) '(a b c d) '(foo bar baz))))))
+		  (test-equal "ck-+"
+		    '(1 2 3 4 5 6 7 8)
+		    (ck-expression (ck-quote (ck-+ '(1 2 3) '(4 5 6) '(7 8)))))
+		  
+		  (test-equal "ck--"
+		    '(1 2 3)
+		    (ck-expression (ck-quote (ck-- '(1 2 3 4 5 6 7 8) (ck-2) (ck-3)))))
 
-	  (test-assert "ck-zero?: true"
-	    (ck-expression (ck-quote (ck-zero? (ck-0)))))
+		  (test-equal "ck-*"
+		    '((1 a foo)
+		      (1 a bar)
+		      (2 a foo)
+		      (2 a bar))
+		    (ck-expression (ck-quote (ck-* '(1 2) '(a) '(foo bar)))))
 
-	  (test-assert "ck-zero?: false"
-	    (ck-expression (ck-quote (ck-not (ck-zero? (ck-1))))))
-	  
-	  (test-assert "ck-even?: true"
-	    (ck-expression (ck-quote (ck-even? (ck-4)))))
-	  
-	  (test-assert "ck-even?: false"
-	    (ck-expression (ck-quote (ck-not (ck-even? (ck-3))))))
-	  
-	  (test-assert "ck-odd?: true"
-	    (ck-expression (ck-quote (ck-odd? (ck-1)))))
-	  
-	  (test-assert "ck-odd?: false"
-	    (ck-expression (ck-quote (ck-not (ck-odd? (ck-2))))))
+		  (test-equal "ck-quotient"
+		    '(1 3)
+		    (ck-expression (ck-quote (ck-quotient '(1 2 3 4 5) (ck-2)))))
 
-	  (test-equal "ck-+"
-	    '(1 2 3 4 5 6 7 8)
-	    (ck-expression (ck-quote (ck-+ '(1 2 3) '(4 5 6) '(7 8)))))
-	  
-	  (test-equal "ck--"
-	    '(1 2 3)
-	    (ck-expression (ck-quote (ck-- '(1 2 3 4 5 6 7 8) (ck-2) (ck-3)))))
+		  (test-equal "ck-remainder"
+		    '(5)
+		    (ck-expression (ck-quote (ck-remainder '(1 2 3 4 5) (ck-2)))))
 
-	  (test-equal "ck-*"
-	    '((1 a foo)
-	      (1 a bar)
-	      (2 a foo)
-	      (2 a bar))
-	    (ck-expression (ck-quote (ck-* '(1 2) '(a) '(foo bar)))))
+		  (test-equal "ck-binom"
+		    '((1 2)
+		      (1 3)
+		      (2 3))
+		    (ck-expression (ck-quote (ck-binom '(1 2 3) (ck-2)))))
+		  
+		  (test-equal "ck-fact"
+		    '((1 2 3)
+		      (1 3 2)
+		      (2 1 3)
+		      (2 3 1)
+		      (3 1 2)
+		      (3 2 1))
+		    (ck-expression (ck-quote (ck-fact '(1 2 3))))))
 
-	  (test-equal "ck-quotient"
-	    '(1 3)
-	    (ck-expression (ck-quote (ck-quotient '(1 2 3 4 5) (ck-2)))))
+      (test-group "Example from specification"
 
-	  (test-equal "ck-remainder"
-	    '(5)
-	    (ck-expression (ck-quote (ck-remainder '(1 2 3 4 5) (ck-2)))))
+		  (define-syntax simple-match
+		    (ck-macro-transformer ()
+		      ((simple-match expr (pattern . body) ...)
+		       (ck-expression
+			`(call-with-current-continuation
+			  (lambda (return)
+			    (let ((e expr))
+			      (or (and-let* 
+				      ,(%compile-pattern 'pattern 'e)
+				    (call-with-values (lambda () . body) return))
+				  ...
+				  (error "does not match" expr)))))))))
 
-	  (test-equal "ck-binom"
-	    '((1 2)
-	      (1 3)
-	      (2 3))
-	    (ck-expression (ck-quote (ck-binom '(1 2 3) (ck-2)))))
-	  
-	  (test-equal "ck-fact"
-	    '((1 2 3)
-	      (1 3 2)
-	      (2 1 3)
-	      (2 3 1)
-	      (3 1 2)
-	      (3 2 1))
-	    (ck-expression (ck-quote (ck-fact '(1 2 3))))))
+		  (define-syntax %compile-pattern
+		    (ck-macro-transformer ()
+		      ((%compile-pattern '() 'e)
+		       '(((null? e))))
+		      ((%compile-pattern '(pattern1 pattern2 ...) 'e)
+		       `(((not (null? e)))
+			 (e1 (car e))
+			 (e2 (cdr e))
+			 ,@(%compile-pattern 'pattern1 'e1)
+			 ,@(%compile-pattern '(pattern2 ...) 'e2)))
+		      ((%compile-pattern 'x 'e)
+		       (ck-if (ck-symbol? 'x)
+			      '((x e))
+			      '(((equal? x e)))))))
 
-	(test-group "Example from specification"
+		  (test-equal 'ten (simple-match 10
+						 (10 'ten)
+						 ((11 x) x)))
 
-	  (define-syntax simple-match
-	    (ck-macro-transformer ()
-	      ((simple-match expr (pattern . body) ...)
-	       (ck-expression
-		`(call-with-current-continuation
-		  (lambda (return)
-		    (let ((e expr))
-		      (or (and-let* 
-			      ,(%compile-pattern 'pattern 'e)
-			    (call-with-values (lambda () . body) return))
-			  ...
-			  (error "does not match" expr)))))))))
-
-	  (define-syntax %compile-pattern
-	    (ck-macro-transformer ()
-	      ((%compile-pattern '() 'e)
-	       '(((null? e))))
-	      ((%compile-pattern '(pattern1 pattern2 ...) 'e)
-	       `(((not (null? e)))
-		 (e1 (car e))
-		 (e2 (cdr e))
-		 ,@(%compile-pattern 'pattern1 'e1)
-		 ,@(%compile-pattern '(pattern2 ...) 'e2)))
-	      ((%compile-pattern 'x 'e)
-	       (ck-if (ck-symbol? 'x)
-		      '((x e))
-		      '(((equal? x e)))))))
-
-	  (test-equal 'ten (simple-match 10
-					 (10 'ten)
-					 ((11 x) x)))
-
-	  (test-equal 'eleven (simple-match '(11 eleven)
-					    (10 'ten)
-					    ((11 x) x))))
+		  (test-equal 'eleven (simple-match '(11 eleven)
+						    (10 'ten)
+						    ((11 x) x))))
 
 
-	(test-end))
+      (test-end)
       )))

--- a/srfi/148/test.sld
+++ b/srfi/148/test.sld
@@ -112,7 +112,18 @@
 		 ((ck-list 'c) => 'd)
 		 '(a d)))))
 	  (ck-expression (ck-quote (m 'foo)))))
-      
+
+      (test-equal "Pattern binding with ellipsis"
+	'(foo bar (foo))
+	(letrec-syntax
+	    ((m
+	      (ck-macro-transformer ()
+		((m 'a 'x ...)
+		 ((ck-make-list (ck-2) 'a) => '(b c))
+		 ((ck-list 'c) => 'd)
+		 '(a x ... d)))))
+	  (ck-expression (ck-quote (m 'foo 'bar)))))
+
       (test-group "General"
 
 	(test-equal "ck-cut: without ..."

--- a/srfi/148/test.sld
+++ b/srfi/148/test.sld
@@ -34,19 +34,19 @@
 	10 
 	(let-syntax
 	    ((m
-	      (ck-macro-transformer ()
+	      (em-syntax-rules ()
 		((m 'a) 'a))))
 	  (m '(define x 10))
 	  x))
 
-      (test-equal "Match quoted pattern with ck-macro use"
+      (test-equal "Match quoted pattern with eager macro use"
 	10
 	(letrec-syntax
 	    ((m1
-	      (ck-macro-transformer ()
+	      (em-syntax-rules ()
 		((m1 'define 'x) '(define x))))
 	     (m2
-	      (ck-macro-transformer ()
+	      (em-syntax-rules ()
 		((m2 '(d y)) '(d y 10)))))
 	  (m2 (m1 'define 'x))
 	  x))
@@ -55,24 +55,24 @@
 	10
 	(letrec-syntax
 	    ((m
-	      (ck-macro-transformer ()
+	      (em-syntax-rules ()
 		((m a) 'a))))
 	  (m (define x 10))
 	  x))
 
-      (test-equal "CK-macro uses in expression contexts"
+      (test-equal "eager macro uses in expression contexts"
 	10
 	(letrec-syntax
 	    ((m
-	      (ck-macro-transformer ()
+	      (em-syntax-rules ()
 		((m 'a 'b) '(+ a b)))))
-	  (ck-expression (m '5 '5))))
+	  (em (m '5 '5))))
 
       (test-equal "Self-quoting literals"
 	10
 	(letrec-syntax
 	    ((m
-	      (ck-macro-transformer ()
+	      (em-syntax-rules ()
 		((m 'a) 10))))
 	  (m 1)))
 
@@ -80,226 +80,226 @@
 	10
 	(letrec-syntax
 	    ((m1
-	      (ck-macro-transformer ()
+	      (em-syntax-rules ()
 		((m1 'a) '(+ a 3))))
 	     (m2
-	      (ck-macro-transformer ()
+	      (em-syntax-rules ()
 		((m2 'a 'b) `(+ ,(m1 'a) ,(m1 'b))))))
-	  (ck-expression (m2 '1 '3))))
+	  (em (m2 '1 '3))))
 
       (test-equal "Quasiquotation in input element"
 	10
 	(letrec-syntax
 	    ((m1
-	      (ck-macro-transformer ()
+	      (em-syntax-rules ()
 		((m1 'a) '(+ a 3))))
 	     (m2
-	      (ck-macro-transformer ()
+	      (em-syntax-rules ()
 		((m2 'a) 'a))))
-	  (ck-expression (m2 `(+ 5 ,(m1 '2))))))
+	  (em (m2 `(+ 5 ,(m1 '2))))))
 
       (test-equal "Quasiquotation: vector"
 	#((a . 1) 2 3)
-	(ck-expression (ck-quote `#(,(ck-cons 'a '1) ,@(ck-list 2 3)))))
+	(em (em-quote `#(,(em-cons 'a '1) ,@(em-list 2 3)))))
 
       (test-equal "Pattern binding"
 	'(foo (foo))
 	(letrec-syntax
 	    ((m
-	      (ck-macro-transformer ()
+	      (em-syntax-rules ()
 		((m 'a)
-		 ((ck-make-list (ck-2) 'a) => '(b c))
-		 ((ck-list 'c) => 'd)
+		 ((em-make-list (em-2) 'a) => '(b c))
+		 ((em-list 'c) => 'd)
 		 '(a d)))))
-	  (ck-expression (ck-quote (m 'foo)))))
+	  (em (em-quote (m 'foo)))))
 
       (test-equal "Pattern binding with ellipsis"
 	'(foo bar (foo))
 	(letrec-syntax
 	    ((m
-	      (ck-macro-transformer ()
+	      (em-syntax-rules ()
 		((m 'a 'x ...)
-		 ((ck-make-list (ck-2) 'a) => '(b c))
-		 ((ck-list 'c) => 'd)
+		 ((em-make-list (em-2) 'a) => '(b c))
+		 ((em-list 'c) => 'd)
 		 '(a x ... d)))))
-	  (ck-expression (ck-quote (m 'foo 'bar)))))
+	  (em (em-quote (m 'foo 'bar)))))
 
       (test-group "General"
 
-	(test-equal "ck-cut: without ..."
+	(test-equal "em-cut: without ..."
 	  '(a . <>)
-	  (ck-expression (ck-quote (ck-apply (ck-cut 'ck-cons <> '<>) 'a '()))))
+	  (em (em-quote (em-apply (em-cut 'em-cons <> '<>) 'a '()))))
 
-	(test-equal "ck-cut: with ..."
+	(test-equal "em-cut: with ..."
 	  '(a b c d)
-	  (ck-expression (ck-quote (ck-apply (ck-cut 'ck-list <> 'b <> ...) 'a 'c 'd '()))))
+	  (em (em-quote (em-apply (em-cut 'em-list <> 'b <> ...) 'a 'c 'd '()))))
 
-	(test-equal "ck-cut: in operator position"
+	(test-equal "em-cut: in operator position"
 	  '(a . <>)
-	  (ck-expression (ck-quote ((ck-cut 'ck-cons <> '<>) 'a))))
+	  (em (em-quote ((em-cut 'em-cons <> '<>) 'a))))
 
-	(test-equal "ck-cute: without ..."
+	(test-equal "em-cute: without ..."
 	  '(a . <>)
-	  (ck-expression (ck-quote (ck-apply (ck-cute 'ck-cons <> '<>) 'a '()))))
+	  (em (em-quote (em-apply (em-cute 'em-cons <> '<>) 'a '()))))
 
-	(test-equal "ck-cute: with ..."
+	(test-equal "em-cute: with ..."
 	  '(a b c d)
-	  (ck-expression (ck-quote (ck-apply (ck-cute 'ck-list <> 'b <> ...) 'a 'c 'd '()))))
+	  (em (em-quote (em-apply (em-cute 'em-list <> 'b <> ...) 'a 'c 'd '()))))
 
-	(test-equal "ck-cute: in operator position"
+	(test-equal "em-cute: in operator position"
 	  '(a . <>)
-	  (ck-expression (ck-quote ((ck-cute 'ck-cons <> '<>) 'a))))
+	  (em (em-quote ((em-cute 'em-cons <> '<>) 'a))))
 
-	(test-equal "ck-constant"
+	(test-equal "em-constant"
 	  'foo
-	  (ck-expression (ck-quote ((ck-constant 'foo) 'a 'b 'c))))
+	  (em (em-quote ((em-constant 'foo) 'a 'b 'c))))
 
-	(test-equal "ck-quote"
+	(test-equal "em-quote"
 	  '(1 2 3)
-	  (ck-expression (ck-quote (ck-list 1 2 3))))
+	  (em (em-quote (em-list 1 2 3))))
 
-	(test-equal "ck-eval"
+	(test-equal "em-eval"
 	  '(1 2 3)
-	  (ck-expression (ck-eval '(ck-list 'list 1 2 3))))
+	  (em (em-eval '(em-list 'list 1 2 3))))
 	
-	(test-equal "ck-apply"
+	(test-equal "em-apply"
 	  '(1 2 3 4 5 6)	
-	  (ck-expression (ck-apply 'ck-list 'list 1 2 3 '(4 5 6))))
+	  (em (em-apply 'em-list 'list 1 2 3 '(4 5 6))))
 	
-	(test-equal "ck-call"
+	(test-equal "em-call"
 	  '(1 2 3)
-	  (ck-expression (ck-quote (ck-call 'ck-list '1 '2 '3))))
+	  (em (em-quote (em-call 'em-list '1 '2 '3))))
 
-	(test-assert "ck-gensym"
-	  (ck-expression (ck-not (ck-bound-identifier=? (ck-gensym) (ck-gensym)))))
+	(test-assert "em-gensym"
+	  (em (em-not (em-bound-identifier=? (em-gensym) (em-gensym)))))
 
-	(test-assert "ck-generate-temporaries"
-	  (ck-expression (ck-not (ck-apply 'ck-bound-identifier=? (ck-generate-temporaries (ck-2)))))))
+	(test-assert "em-generate-temporaries"
+	  (em (em-not (em-apply 'em-bound-identifier=? (em-generate-temporaries (em-2)))))))
       
       (test-group "Boolean logic"
 	
-	(test-equal "ck-if: true test"
+	(test-equal "em-if: true test"
 	  'true
-	  (ck-expression (ck-quote (ck-if '#t 'true 'false))))
+	  (em (em-quote (em-if '#t 'true 'false))))
 
-	(test-equal "ck-if: false test"
+	(test-equal "em-if: false test"
 	  'false
-	  (ck-expression (ck-quote (ck-if '#f 'true 'false))))
+	  (em (em-quote (em-if '#f 'true 'false))))
 
-	(test-equal "ck-not"
+	(test-equal "em-not"
 	  'false
-	  (ck-expression (ck-quote (ck-if (ck-not '#t) 'true 'false))))
+	  (em (em-quote (em-if (em-not '#t) 'true 'false))))
 
-	(test-equal "ck-or"
+	(test-equal "em-or"
 	  'a
-	  (ck-expression (ck-or '#f ''a (ck-error "fail"))))
+	  (em (em-or '#f ''a (em-error "fail"))))
 
-	(test-equal "ck-and"
+	(test-equal "em-and"
 	  '#f
-	  (ck-expression (ck-and ''a ''b '#f (ck-error "fail"))))
+	  (em (em-and ''a ''b '#f (em-error "fail"))))
 
-	(test-equal "ck-null?: true"
+	(test-equal "em-null?: true"
 	  'true
-	  (ck-expression (ck-quote (ck-if (ck-null? '()) 'true 'false))))
+	  (em (em-quote (em-if (em-null? '()) 'true 'false))))
 
-	(test-equal "ck-null?: false"
+	(test-equal "em-null?: false"
 	  'false
-	  (ck-expression (ck-quote (ck-if (ck-null? 'x) 'true 'false))))
+	  (em (em-quote (em-if (em-null? 'x) 'true 'false))))
 
-	(test-equal "ck-pair?: true"
+	(test-equal "em-pair?: true"
 	  'true
-	  (ck-expression (ck-quote (ck-if (ck-pair? '(a . b)) 'true 'false))))
+	  (em (em-quote (em-if (em-pair? '(a . b)) 'true 'false))))
 
-	(test-equal "ck-pair?: false"
+	(test-equal "em-pair?: false"
 	  'false
-	  (ck-expression (ck-quote (ck-if (ck-pair? '()) 'true 'false))))
+	  (em (em-quote (em-if (em-pair? '()) 'true 'false))))
 
-	(test-equal "ck-list?: true"
+	(test-equal "em-list?: true"
 	  'true
-	  (ck-expression (ck-quote (ck-if (ck-list? '(a b)) 'true 'false))))
+	  (em (em-quote (em-if (em-list? '(a b)) 'true 'false))))
 
-	(test-equal "ck-list?: false"
+	(test-equal "em-list?: false"
 	  'false
-	  (ck-expression (ck-quote (ck-if (ck-list? '(a . b)) 'true 'false))))
+	  (em (em-quote (em-if (em-list? '(a . b)) 'true 'false))))
 	
-	(test-equal "ck-boolean?: true"
+	(test-equal "em-boolean?: true"
 	  'true
-	  (ck-expression (ck-quote (ck-if (ck-boolean? '#f) 'true 'false))))
+	  (em (em-quote (em-if (em-boolean? '#f) 'true 'false))))
 
-	(test-equal "ck-boolean?: false"
+	(test-equal "em-boolean?: false"
 	  'false
-	  (ck-expression (ck-quote (ck-if (ck-boolean? '(a . b)) 'true 'false))))
+	  (em (em-quote (em-if (em-boolean? '(a . b)) 'true 'false))))
 	
-	(test-equal "ck-vector?: true"
+	(test-equal "em-vector?: true"
 	  'true
-	  (ck-expression (ck-quote (ck-if (ck-vector? '#(a b)) 'true 'false))))
+	  (em (em-quote (em-if (em-vector? '#(a b)) 'true 'false))))
 	
-	(test-equal "ck-vector?: false"
+	(test-equal "em-vector?: false"
 	  'false
-	  (ck-expression (ck-quote (ck-if (ck-vector? '(a . b)) 'true 'false))))
+	  (em (em-quote (em-if (em-vector? '(a . b)) 'true 'false))))
 
-	(test-equal "ck-symbol?: true"
+	(test-equal "em-symbol?: true"
 	  'true
-	  (ck-expression (ck-quote (ck-if (ck-symbol? 'a) 'true 'false))))
+	  (em (em-quote (em-if (em-symbol? 'a) 'true 'false))))
 
-	(test-equal "ck-symbol?: false"
+	(test-equal "em-symbol?: false"
 	  'false
-	  (ck-expression (ck-quote (ck-if (ck-symbol? '(a . b)) 'true 'false))))
+	  (em (em-quote (em-if (em-symbol? '(a . b)) 'true 'false))))
 
-	(test-equal "ck-bound-identifier=?: true"
+	(test-equal "em-bound-identifier=?: true"
 	  'true
 	  (letrec-syntax
 	      ((m
 		(syntax-rules ()
 		  ((m a b)
-		   (ck-expression (ck-quote (ck-if (ck-bound-identifier=? 'a 'b) 'true 'false)))))))
+		   (em (em-quote (em-if (em-bound-identifier=? 'a 'b) 'true 'false)))))))
 	    (m c c)))
 
-	(test-equal "ck-bound-identifier=?: false"
+	(test-equal "em-bound-identifier=?: false"
 	  'false
 	  (letrec-syntax
 	      ((m
 		(syntax-rules ()
 		  ((m a b)
-		   (ck-expression (ck-quote (ck-if (ck-bound-identifier=? 'a 'b) 'true 'false)))))))
+		   (em (em-quote (em-if (em-bound-identifier=? 'a 'b) 'true 'false)))))))
 	    (m c d)))
 
-	(test-equal "ck-free-identifier=?: true"
+	(test-equal "em-free-identifier=?: true"
 	  'true
 	  (letrec-syntax
 	      ((m
 		(syntax-rules ()
 		  ((m a)
-		   (ck-expression (ck-quote (ck-if (ck-free-identifier=? 'a 'm) 'true 'false)))))))
+		   (em (em-quote (em-if (em-free-identifier=? 'a 'm) 'true 'false)))))))
 	    (m m)))
 
-	(test-equal "ck-free-identifier=?: false"
+	(test-equal "em-free-identifier=?: false"
 	  'false
 	  (letrec-syntax
 	      ((m
 		(syntax-rules ()
 		  ((m a)
-		   (ck-expression (ck-quote (ck-if (ck-free-identifier=? 'a 'm) 'true 'false)))))))
+		   (em (em-quote (em-if (em-free-identifier=? 'a 'm) 'true 'false)))))))
 	    (m c)))
 	
-	(test-equal "ck-equal?: numbers/true"
+	(test-equal "em-equal?: numbers/true"
 	  'true
-	  (ck-expression (ck-quote (ck-if (ck-equal? '10 '10) 'true 'false))))
+	  (em (em-quote (em-if (em-equal? '10 '10) 'true 'false))))
 
-	(test-equal "ck-equal?: numbers/false"
+	(test-equal "em-equal?: numbers/false"
 	  'false
-	  (ck-expression (ck-quote (ck-if (ck-equal? '10 "foo") 'true 'false))))
+	  (em (em-quote (em-if (em-equal? '10 "foo") 'true 'false))))
 
-	(test-equal "ck-equal?: recursive/true"
+	(test-equal "em-equal?: recursive/true"
 	  'true
-	  (ck-expression (ck-quote (ck-if (ck-equal? '(a . #(1 2 ("x" "y")))
+	  (em (em-quote (em-if (em-equal? '(a . #(1 2 ("x" "y")))
 						     '(a . #(1 2 ("x" "y"))))
 					  'true
 					  'false))))
 	
-	(test-equal "ck-equal?: recursive/false"
+	(test-equal "em-equal?: recursive/false"
 	  'false
-	  (ck-expression (ck-quote (ck-if (ck-equal? '(a . #(1 2 ("x" y)))
+	  (em (em-quote (em-if (em-equal? '(a . #(1 2 ("x" y)))
 						     '(a . #(1 2 ("x" "y"))))
 					  'true
 					  'false)))))
@@ -307,400 +307,400 @@
       (test-group "List processing"
 
 	(test-group "Constructors"        
-	  (test-equal "ck-cons"
+	  (test-equal "em-cons"
 	    10
 	    (let ()
-	      (ck-cons 'define '(x 10))
+	      (em-cons 'define '(x 10))
 	      x))
 
-	  (test-equal "ck-cons*"
+	  (test-equal "em-cons*"
 	    '(a b . c)
-	    (ck-expression (ck-quote (ck-cons* 'a 'b 'c))))
+	    (em (em-quote (em-cons* 'a 'b 'c))))
 
-	  (test-equal "ck-list"
+	  (test-equal "em-list"
 	    10
 	    (let ()
-	      (ck-list 'define 'x '10)
+	      (em-list 'define 'x '10)
 	      x))
 
-	  (test-equal "ck-make-list"
+	  (test-equal "em-make-list"
 	    '(a a a a a)
-	    (ck-expression (ck-quote (ck-make-list (ck-5) 'a)))))
+	    (em (em-quote (em-make-list (em-5) 'a)))))
 
 	(test-group "Selectors"
 
-	  (test-equal "ck-car"
+	  (test-equal "em-car"
 	    'car
-	    (ck-expression (ck-car '('car . 'cdr))))
+	    (em (em-car '('car . 'cdr))))
 	  
-	  (test-equal "ck-car"
+	  (test-equal "em-car"
 	    'cdr
-	    (ck-expression (ck-cdr '('car . 'cdr))))
+	    (em (em-cdr '('car . 'cdr))))
 	  
-	  (test-equal "ck-caar"
+	  (test-equal "em-caar"
 	    'a
-	    (ck-expression (ck-quote (ck-caar '((a . b) . c)))))
+	    (em (em-quote (em-caar '((a . b) . c)))))
 
-	  (test-equal "ck-cadr"
+	  (test-equal "em-cadr"
 	    'c
-	    (ck-expression (ck-quote (ck-cadr '((a . b) . (c . d))))))
+	    (em (em-quote (em-cadr '((a . b) . (c . d))))))
 
-	  (test-equal "ck-cdar"
+	  (test-equal "em-cdar"
 	    'b
-	    (ck-expression (ck-quote (ck-cdar '((a . b) . c)))))
+	    (em (em-quote (em-cdar '((a . b) . c)))))
 
-	  (test-equal "ck-cddr"
+	  (test-equal "em-cddr"
 	    'd
-	    (ck-expression (ck-quote (ck-cddr '((a . b) . (c . d))))))
+	    (em (em-quote (em-cddr '((a . b) . (c . d))))))
 
-	  (test-equal "ck-first"
+	  (test-equal "em-first"
 	    1
-	    (ck-expression (ck-quote (ck-first '(1 2 3 4 5 6 7 8 9 10)))))
+	    (em (em-quote (em-first '(1 2 3 4 5 6 7 8 9 10)))))
 
-	  (test-equal "ck-second"
+	  (test-equal "em-second"
 	    2
-	    (ck-expression (ck-quote (ck-second '(1 2 3 4 5 6 7 8 9 10)))))
+	    (em (em-quote (em-second '(1 2 3 4 5 6 7 8 9 10)))))
 
-	  (test-equal "ck-third"
+	  (test-equal "em-third"
 	    3
-	    (ck-expression (ck-quote (ck-third '(1 2 3 4 5 6 7 8 9 10)))))
+	    (em (em-quote (em-third '(1 2 3 4 5 6 7 8 9 10)))))
 
-	  (test-equal "ck-fourth"
+	  (test-equal "em-fourth"
 	    4
-	    (ck-expression (ck-quote (ck-fourth '(1 2 3 4 5 6 7 8 9 10)))))
+	    (em (em-quote (em-fourth '(1 2 3 4 5 6 7 8 9 10)))))
 
-	  (test-equal "ck-fifth"
+	  (test-equal "em-fifth"
 	    5
-	    (ck-expression (ck-quote (ck-fifth '(1 2 3 4 5 6 7 8 9 10)))))
+	    (em (em-quote (em-fifth '(1 2 3 4 5 6 7 8 9 10)))))
 
-	  (test-equal "ck-sixth"
+	  (test-equal "em-sixth"
 	    6
-	    (ck-expression (ck-quote (ck-sixth '(1 2 3 4 5 6 7 8 9 10)))))
+	    (em (em-quote (em-sixth '(1 2 3 4 5 6 7 8 9 10)))))
 
-	  (test-equal "ck-seventh"
+	  (test-equal "em-seventh"
 	    7
-	    (ck-expression (ck-quote (ck-seventh '(1 2 3 4 5 6 7 8 9 10)))))
+	    (em (em-quote (em-seventh '(1 2 3 4 5 6 7 8 9 10)))))
 
-	  (test-equal "ck-eighth"
+	  (test-equal "em-eighth"
 	    8
-	    (ck-expression (ck-quote (ck-eighth '(1 2 3 4 5 6 7 8 9 10)))))
+	    (em (em-quote (em-eighth '(1 2 3 4 5 6 7 8 9 10)))))
 
-	  (test-equal "ck-ninth"
+	  (test-equal "em-ninth"
 	    9
-	    (ck-expression (ck-quote (ck-ninth '(1 2 3 4 5 6 7 8 9 10)))))
+	    (em (em-quote (em-ninth '(1 2 3 4 5 6 7 8 9 10)))))
 
-	  (test-equal "ck-tenth"
+	  (test-equal "em-tenth"
 	    10
-	    (ck-expression (ck-quote (ck-tenth '(1 2 3 4 5 6 7 8 9 10)))))
+	    (em (em-quote (em-tenth '(1 2 3 4 5 6 7 8 9 10)))))
 	  
-	  (test-equal "ck-list-tail"
+	  (test-equal "em-list-tail"
 	    '(3 4 5)
-	    (ck-expression (ck-quote (ck-list-tail '(1 2 3 4 5) (ck-2)))))
+	    (em (em-quote (em-list-tail '(1 2 3 4 5) (em-2)))))
 
-	  (test-equal "ck-list-ref"
+	  (test-equal "em-list-ref"
 	    '4
-	    (ck-expression (ck-quote (ck-list-ref '(1 2 3 4 5) (ck-3)))))
+	    (em (em-quote (em-list-ref '(1 2 3 4 5) (em-3)))))
 
-	  (test-equal "ck-take"
+	  (test-equal "em-take"
 	    '(1 2 3)
-	    (ck-expression (ck-quote (ck-take '(1 2 3) (ck-3)))))
+	    (em (em-quote (em-take '(1 2 3) (em-3)))))
 
-	  (test-equal "ck-take-right"
+	  (test-equal "em-take-right"
 	    '(2 3 . d)
-	    (ck-expression (ck-quote (ck-take-right '(0 1 2 3 . d) (ck-2)))))
+	    (em (em-quote (em-take-right '(0 1 2 3 . d) (em-2)))))
 
-	  (test-equal "ck-drop-right"
+	  (test-equal "em-drop-right"
 	    '(0 1)
-	    (ck-expression (ck-quote (ck-drop-right '(0 1 2 3 . d) (ck-2)))))
+	    (em (em-quote (em-drop-right '(0 1 2 3 . d) (em-2)))))
 
-	  (test-equal "ck-last"
+	  (test-equal "em-last"
 	    'c
-	    (ck-expression (ck-quote (ck-last '(a b c)))))
+	    (em (em-quote (em-last '(a b c)))))
 
-	  (test-equal "ck-last-pair"
+	  (test-equal "em-last-pair"
 	    '(c)
-	    (ck-expression (ck-quote (ck-last-pair '(a b c))))))
+	    (em (em-quote (em-last-pair '(a b c))))))
 
 	(test-group "Miscellaneous"
-	  (test-equal "ck-append"
+	  (test-equal "em-append"
 	    10
 	    (let ()
-	      (ck-append '(define) '(x) '(10))
+	      (em-append '(define) '(x) '(10))
 	      x))
 	  
-	  (test-equal "ck-reverse"
+	  (test-equal "em-reverse"
 	    '(5 4 3 2 1)
-	    (ck-expression (ck-quote (ck-reverse '(1 2 3 4 5))))))
+	    (em (em-quote (em-reverse '(1 2 3 4 5))))))
 	
 	(test-group "Folding, unfolding and mapping"
 	  
-	  (test-equal "ck-fold"
+	  (test-equal "em-fold"
 	    '(* b 2 (* a 1 ()))
-	    (ck-expression (ck-quote (ck-fold (ck-cute 'ck-list '* <> ...)
+	    (em (em-quote (em-fold (em-cute 'em-list '* <> ...)
 					      '()
 					      '(a b c)
 					      '(1 2)))))
 	  
-	  (test-equal "ck-fold-right"
+	  (test-equal "em-fold-right"
 	    '(* a 1 (* b 2 ()))
-	    (ck-expression (ck-quote (ck-fold-right (ck-cute 'ck-list '* <> ...)
+	    (em (em-quote (em-fold-right (em-cute 'em-list '* <> ...)
 						    '()
 						    '(a b c)
 						    '(1 2)))))
 	  
-	  (test-equal "ck-unfold"
+	  (test-equal "em-unfold"
 	    '(1 2 3)
-	    (ck-expression (ck-quote (ck-unfold 'ck-null? 'ck-car 'ck-cdr '(1 2 3)))))
+	    (em (em-quote (em-unfold 'em-null? 'em-car 'em-cdr '(1 2 3)))))
 	  
-	  (test-equal "ck-unfold-right"
+	  (test-equal "em-unfold-right"
 	    '(3 2 1)
-	    (ck-expression (ck-quote (ck-unfold-right 'ck-null? 'ck-car 'ck-cdr '(1 2 3)))))
+	    (em (em-quote (em-unfold-right 'em-null? 'em-car 'em-cdr '(1 2 3)))))
 
-	  (test-equal "ck-map"
+	  (test-equal "em-map"
 	    '((* . 1) (* . 2) (* . 3))
-	    (ck-expression (ck-quote (ck-map (ck-cut 'ck-cons '* <>) '(1 2 3)))))
+	    (em (em-quote (em-map (em-cut 'em-cons '* <>) '(1 2 3)))))
 
-	  (test-equal "ck-append-map"
+	  (test-equal "em-append-map"
 	    '(1 a 2 b 3 c)
-	    (ck-expression (ck-quote (ck-append-map 'ck-list '(1 2 3) '(a b c))))))
+	    (em (em-quote (em-append-map 'em-list '(1 2 3) '(a b c))))))
 
 	(test-group "Filtering"
 
-	  (test-equal "ck-filter"
+	  (test-equal "em-filter"
 	    '(foo foo)
-	    (ck-expression (ck-quote (ck-filter (ck-cut 'ck-equal? 'foo <>) '(foo bar baz foo)))))
+	    (em (em-quote (em-filter (em-cut 'em-equal? 'foo <>) '(foo bar baz foo)))))
 
-	  (test-equal "ck-remove"
+	  (test-equal "em-remove"
 	    '(bar baz)
-	    (ck-expression (ck-quote (ck-remove (ck-cut 'ck-equal? 'foo <>) '(foo bar baz foo))))))
+	    (em (em-quote (em-remove (em-cut 'em-equal? 'foo <>) '(foo bar baz foo))))))
 
 	(test-group "Searching"
 	  (define-syntax pred
-	    (ck-macro-transformer ()
-	      ((pred 'x 'y) (ck-equal? 'x (ck-car 'y)))))
+	    (em-syntax-rules ()
+	      ((pred 'x 'y) (em-equal? 'x (em-car 'y)))))
 
-	  (test-equal "ck-find"
+	  (test-equal "em-find"
 	    '(2 . b)
-	    (ck-expression (ck-quote (ck-find (ck-cut 'pred 2 <>) '((1 . a) (2 . b) (3 . c))))))
+	    (em (em-quote (em-find (em-cut 'pred 2 <>) '((1 . a) (2 . b) (3 . c))))))
 
-	  (test-equal "ck-find-tail"
+	  (test-equal "em-find-tail"
 	    '((2 . b) (3 . c))
-	    (ck-expression (ck-quote (ck-find-tail (ck-cut 'pred 2 <>) '((1 . a) (2 . b) (3 . c))))))
+	    (em (em-quote (em-find-tail (em-cut 'pred 2 <>) '((1 . a) (2 . b) (3 . c))))))
 
-	  (test-equal "ck-take-while"
+	  (test-equal "em-take-while"
 	    '()
-	    (ck-expression (ck-quote (ck-take-while (ck-cut 'pred 2 <>) '((1 . a) (2 . b) (3 . c))))))
+	    (em (em-quote (em-take-while (em-cut 'pred 2 <>) '((1 . a) (2 . b) (3 . c))))))
 
-	  (test-equal "ck-drop-while"
+	  (test-equal "em-drop-while"
 	    '((1 . a) (2 . b) (3 . c))
-	    (ck-expression (ck-quote (ck-drop-while (ck-cut 'pred 2 <>) '((1 . a) (2 . b) (3 . c))))))
+	    (em (em-quote (em-drop-while (em-cut 'pred 2 <>) '((1 . a) (2 . b) (3 . c))))))
 
-	  (test-equal "ck-any"
+	  (test-equal "em-any"
 	    '#t
-	    (ck-expression (ck-quote (ck-any (ck-cut 'pred 2 <>) '((1 . a) (2 . b) (3 . c))))))
+	    (em (em-quote (em-any (em-cut 'pred 2 <>) '((1 . a) (2 . b) (3 . c))))))
 
-	  (test-equal "ck-every"
+	  (test-equal "em-every"
 	    '#f
-	     (ck-expression (ck-quote (ck-every (ck-cut 'pred 2 <>) '((1 . a) (2 . b) (3 . c))))))
+	     (em (em-quote (em-every (em-cut 'pred 2 <>) '((1 . a) (2 . b) (3 . c))))))
 
-	  (test-equal "ck-member"
+	  (test-equal "em-member"
 	    '(2 3)
-	    (ck-expression (ck-quote (ck-member '2 '(1 2 3) 'ck-equal?)))))
+	    (em (em-quote (em-member '2 '(1 2 3) 'em-equal?)))))
 
 	(test-group "Association lists"
 
-	  (test-equal "ck-assoc"
+	  (test-equal "em-assoc"
 	    '(2 . b)
-	    (ck-expression (ck-quote (ck-assoc '2 '((1 . a) (2 . b) (3 . c))))))
+	    (em (em-quote (em-assoc '2 '((1 . a) (2 . b) (3 . c))))))
 
-	  (test-equal "ck-assoc"
+	  (test-equal "em-assoc"
 	    '((1 . a) (3 . c))
-	    (ck-expression (ck-quote (ck-alist-delete '2 '((1 . a) (2 . b) (3 . c)))))))
+	    (em (em-quote (em-alist-delete '2 '((1 . a) (2 . b) (3 . c)))))))
 
 	(test-group "Set operations"
 
-	  (test-assert "ck-set<=: true"
-	    (ck-expression (ck-set<= 'ck-equal? '(1 2) '(1 2 3))))
+	  (test-assert "em-set<=: true"
+	    (em (em-set<= 'em-equal? '(1 2) '(1 2 3))))
 
-	  (test-assert "ck-set<=: false"
-	    (ck-expression (ck-not (ck-set<= 'ck-equal? '(3 1 2 3) '(1 2)))))
+	  (test-assert "em-set<=: false"
+	    (em (em-not (em-set<= 'em-equal? '(3 1 2 3) '(1 2)))))
 	  
-	  (test-assert "ck-set-adjoin"
-	    (ck-expression (ck-= (ck-set-adjoin 'ck-equal? '(1 2 3) '2 '4) (ck-4))))
+	  (test-assert "em-set-adjoin"
+	    (em (em= (em-set-adjoin 'em-equal? '(1 2 3) '2 '4) (em-4))))
 
-	  (test-assert "ck-set-union"
-	    (ck-expression (ck-= (ck-set-union 'ck-equal? '(1 2 3) '(3 4 5)) (ck-5))))
+	  (test-assert "em-set-union"
+	    (em (em= (em-set-union 'em-equal? '(1 2 3) '(3 4 5)) (em-5))))
 
-	  (test-assert "ck-set-intersection"
-	    (ck-expression (ck-= (ck-set-intersection 'ck-equal? '(1 2 3) '(3 4 5)) (ck-1))))
+	  (test-assert "em-set-intersection"
+	    (em (em= (em-set-intersection 'em-equal? '(1 2 3) '(3 4 5)) (em-1))))
 
-	  (test-assert "ck-set-difference"
-	    (ck-expression (ck-= (ck-set-difference 'ck-equal? '(1 2 3) '(3 4 5)) (ck-2))))
+	  (test-assert "em-set-difference"
+	    (em (em= (em-set-difference 'em-equal? '(1 2 3) '(3 4 5)) (em-2))))
 
-	  (test-assert "ck-set-xor"
-	    (ck-expression (ck-= (ck-set-xor 'ck-equal? '(1 2 3) '(3 4 5)) (ck-4))))))
+	  (test-assert "em-set-xor"
+	    (em (em= (em-set-xor 'em-equal? '(1 2 3) '(3 4 5)) (em-4))))))
 
       ;; Vector processing
       (test-group "Vector processing"
 		  
-		  (test-equal "ck-vector"
+		  (test-equal "em-vector"
 		    #(10 20 30)
-		    (ck-expression (ck-quote (ck-vector 10 20 30))))
+		    (em (em-quote (em-vector 10 20 30))))
 
-		  (test-equal "ck-list->vector"
+		  (test-equal "em-list->vector"
 		    #(10 20 30)
-		    (ck-expression (ck-quote (ck-list->vector '(10 20 30)))))
+		    (em (em-quote (em-list->vector '(10 20 30)))))
 		  
-		  (test-equal "ck-vector->list"
+		  (test-equal "em-vector->list"
 		    '(10 20 30)
-		    (ck-expression (ck-quote (ck-vector->list #(10 20 30)))))
+		    (em (em-quote (em-vector->list #(10 20 30)))))
 
-		  (test-equal "ck-vector-map"
+		  (test-equal "em-vector-map"
 		    '#((1 . a) (2 . b) (3 . c))
-		    (ck-expression (ck-quote (ck-vector-map 'ck-cons '#(1 2 3) '#(a b c d)))))
+		    (em (em-quote (em-vector-map 'em-cons '#(1 2 3) '#(a b c d)))))
 		  
-		  (test-equal "ck-vector-ref"
+		  (test-equal "em-vector-ref"
 		    20
-		    (ck-expression (ck-quote (ck-vector-ref #(10 20 30) (ck-1))))))
+		    (em (em-quote (em-vector-ref #(10 20 30) (em-1))))))
 	
       (test-group "Combinatorics"
 
-		  (test-equal "ck-0"
+		  (test-equal "em-0"
 		    #t
-		    (ck-expression (ck-= '() (ck-0))))
+		    (em (em= '() (em-0))))
 
-		  (test-equal "ck-1"
+		  (test-equal "em-1"
 		    #t
-		    (ck-expression (ck-= '(0) (ck-1))))
+		    (em (em= '(0) (em-1))))
 
-		  (test-equal "ck-2"
+		  (test-equal "em-2"
 		    #t
-		    (ck-expression (ck-= '(0 1) (ck-2))))
+		    (em (em= '(0 1) (em-2))))
 
-		  (test-equal "ck-3"
+		  (test-equal "em-3"
 		    #t
-		    (ck-expression (ck-= '(0 1 2) (ck-3))))
+		    (em (em= '(0 1 2) (em-3))))
 
-		  (test-equal "ck-4"
+		  (test-equal "em-4"
 		    #t
-		    (ck-expression (ck-= '(0 1 2 3) (ck-4))))
+		    (em (em= '(0 1 2 3) (em-4))))
 
-		  (test-equal "ck-5"
+		  (test-equal "em-5"
 		    #t
-		    (ck-expression (ck-= '(0 1 2 3 4) (ck-5))))
+		    (em (em= '(0 1 2 3 4) (em-5))))
 
-		  (test-equal "ck-6"
+		  (test-equal "em-6"
 		    #t
-		    (ck-expression (ck-= '(0 1 2 3 4 5) (ck-6))))
+		    (em (em= '(0 1 2 3 4 5) (em-6))))
 
-		  (test-equal "ck-7"
+		  (test-equal "em-7"
 		    #t
-		    (ck-expression (ck-= '(0 1 2 3 4 5 6) (ck-7))))
+		    (em (em= '(0 1 2 3 4 5 6) (em-7))))
 
-		  (test-equal "ck-8"
+		  (test-equal "em-8"
 		    #t
-		    (ck-expression (ck-= '(0 1 2 3 4 5 6 7) (ck-8))))
+		    (em (em= '(0 1 2 3 4 5 6 7) (em-8))))
 
-		  (test-equal "ck-9"
+		  (test-equal "em-9"
 		    #t
-		    (ck-expression (ck-= '(0 1 2 3 4 5 6 7 8) (ck-9))))
+		    (em (em= '(0 1 2 3 4 5 6 7 8) (em-9))))
 		  
-		  (test-equal "ck-10"
+		  (test-equal "em-10"
 		    #t
-		    (ck-expression (ck-= '(0 1 2 3 4 5 6 7 8 9) (ck-10))))
+		    (em (em= '(0 1 2 3 4 5 6 7 8 9) (em-10))))
 
-		  (test-assert "ck-=: true"
-		    (ck-expression (ck-quote (ck-= '(1 2 3) '(a b c) '(foo bar baz)))))
+		  (test-assert "em=: true"
+		    (em (em-quote (em= '(1 2 3) '(a b c) '(foo bar baz)))))
 		  
-		  (test-assert "ck-=: false"
-		    (ck-expression (ck-quote (ck-not (ck-= '(1 2 3) '(a b c d) '(foo bar baz))))))
+		  (test-assert "em=: false"
+		    (em (em-quote (em-not (em= '(1 2 3) '(a b c d) '(foo bar baz))))))
 
-		  (test-assert "ck-<: true"
-		    (ck-expression (ck-quote (ck-< '(1) '(a b) '(foo bar baz)))))
+		  (test-assert "em<: true"
+		    (em (em-quote (em< '(1) '(a b) '(foo bar baz)))))
 		  
-		  (test-assert "ck-<: false"
-		    (ck-expression (ck-quote (ck-not (ck-< '(1 2) '(a b c) '(foo bar baz))))))
+		  (test-assert "em<: false"
+		    (em (em-quote (em-not (em< '(1 2) '(a b c) '(foo bar baz))))))
 
-		  (test-assert "ck-<=: true"
-		    (ck-expression (ck-quote (ck-<= '(1 2) '(a b c) '(foo bar baz)))))
+		  (test-assert "em<=: true"
+		    (em (em-quote (em<= '(1 2) '(a b c) '(foo bar baz)))))
 		  
-		  (test-assert "ck-<=: false"
-		    (ck-expression (ck-quote (ck-not (ck-<= '(1 2 3) '(a b c d) '(foo bar baz))))))
+		  (test-assert "em<=: false"
+		    (em (em-quote (em-not (em<= '(1 2 3) '(a b c d) '(foo bar baz))))))
 
-		  (test-assert "ck->: true"
-		    (ck-expression (ck-quote (ck-> '(1 2 3 4 5) '(a b c d) '(foo bar baz)))))
+		  (test-assert "em>: true"
+		    (em (em-quote (em> '(1 2 3 4 5) '(a b c d) '(foo bar baz)))))
 		  
-		  (test-assert "ck->: false"
-		    (ck-expression (ck-quote (ck-not (ck-> '(1 2 3) '(a b c d) '(foo bar baz))))))
+		  (test-assert "em>: false"
+		    (em (em-quote (em-not (em> '(1 2 3) '(a b c d) '(foo bar baz))))))
 
-		  (test-assert "ck->=: true"
-		    (ck-expression (ck-quote (ck->= '(1 2 3 4) '(a b c d) '(foo bar baz)))))
+		  (test-assert "em>=: true"
+		    (em (em-quote (em>= '(1 2 3 4) '(a b c d) '(foo bar baz)))))
 		  
-		  (test-assert "ck->=: false"
-		    (ck-expression (ck-quote (ck-not (ck->= '(1 2 3) '(a b c d) '(foo bar baz))))))
+		  (test-assert "em>=: false"
+		    (em (em-quote (em-not (em>= '(1 2 3) '(a b c d) '(foo bar baz))))))
 
-		  (test-assert "ck-zero?: true"
-		    (ck-expression (ck-quote (ck-zero? (ck-0)))))
+		  (test-assert "em-zero?: true"
+		    (em (em-quote (em-zero? (em-0)))))
 
-		  (test-assert "ck-zero?: false"
-		    (ck-expression (ck-quote (ck-not (ck-zero? (ck-1))))))
+		  (test-assert "em-zero?: false"
+		    (em (em-quote (em-not (em-zero? (em-1))))))
 		  
-		  (test-assert "ck-even?: true"
-		    (ck-expression (ck-quote (ck-even? (ck-4)))))
+		  (test-assert "em-even?: true"
+		    (em (em-quote (em-even? (em-4)))))
 		  
-		  (test-assert "ck-even?: false"
-		    (ck-expression (ck-quote (ck-not (ck-even? (ck-3))))))
+		  (test-assert "em-even?: false"
+		    (em (em-quote (em-not (em-even? (em-3))))))
 		  
-		  (test-assert "ck-odd?: true"
-		    (ck-expression (ck-quote (ck-odd? (ck-1)))))
+		  (test-assert "em-odd?: true"
+		    (em (em-quote (em-odd? (em-1)))))
 		  
-		  (test-assert "ck-odd?: false"
-		    (ck-expression (ck-quote (ck-not (ck-odd? (ck-2))))))
+		  (test-assert "em-odd?: false"
+		    (em (em-quote (em-not (em-odd? (em-2))))))
 
-		  (test-equal "ck-+"
+		  (test-equal "em+"
 		    '(1 2 3 4 5 6 7 8)
-		    (ck-expression (ck-quote (ck-+ '(1 2 3) '(4 5 6) '(7 8)))))
+		    (em (em-quote (em+ '(1 2 3) '(4 5 6) '(7 8)))))
 		  
-		  (test-equal "ck--"
+		  (test-equal "em-"
 		    '(1 2 3)
-		    (ck-expression (ck-quote (ck-- '(1 2 3 4 5 6 7 8) (ck-2) (ck-3)))))
+		    (em (em-quote (em- '(1 2 3 4 5 6 7 8) (em-2) (em-3)))))
 
-		  (test-equal "ck-*"
+		  (test-equal "em*"
 		    '((1 a foo)
 		      (1 a bar)
 		      (2 a foo)
 		      (2 a bar))
-		    (ck-expression (ck-quote (ck-* '(1 2) '(a) '(foo bar)))))
+		    (em (em-quote (em* '(1 2) '(a) '(foo bar)))))
 
-		  (test-equal "ck-quotient"
+		  (test-equal "em-quotient"
 		    '(1 3)
-		    (ck-expression (ck-quote (ck-quotient '(1 2 3 4 5) (ck-2)))))
+		    (em (em-quote (em-quotient '(1 2 3 4 5) (em-2)))))
 
-		  (test-equal "ck-remainder"
+		  (test-equal "em-remainder"
 		    '(5)
-		    (ck-expression (ck-quote (ck-remainder '(1 2 3 4 5) (ck-2)))))
+		    (em (em-quote (em-remainder '(1 2 3 4 5) (em-2)))))
 
-		  (test-equal "ck-binom"
+		  (test-equal "em-binom"
 		    '((1 2)
 		      (1 3)
 		      (2 3))
-		    (ck-expression (ck-quote (ck-binom '(1 2 3) (ck-2)))))
+		    (em (em-quote (em-binom '(1 2 3) (em-2)))))
 		  
-		  (test-equal "ck-fact"
+		  (test-equal "em-fact"
 		    '((1 2 3)
 		      (1 3 2)
 		      (2 1 3)
 		      (2 3 1)
 		      (3 1 2)
 		      (3 2 1))
-		    (ck-expression (ck-quote (ck-fact '(1 2 3))))))
+		    (em (em-quote (em-fact '(1 2 3))))))
 
       (test-group "Example from specification"
 
 		  (define-syntax simple-match
-		    (ck-macro-transformer ()
+		    (em-syntax-rules ()
 		      ((simple-match expr (pattern . body) ...)
-		       (ck-expression
+		       (em
 			`(call-with-current-continuation
 			  (lambda (return)
 			    (let ((e expr))
@@ -711,7 +711,7 @@
 				  (error "does not match" expr)))))))))
 
 		  (define-syntax %compile-pattern
-		    (ck-macro-transformer ()
+		    (em-syntax-rules ()
 		      ((%compile-pattern '() 'e)
 		       '(((null? e))))
 		      ((%compile-pattern '(pattern1 pattern2 ...) 'e)
@@ -721,7 +721,7 @@
 			 ,@(%compile-pattern 'pattern1 'e1)
 			 ,@(%compile-pattern '(pattern2 ...) 'e2)))
 		      ((%compile-pattern 'x 'e)
-		       (ck-if (ck-symbol? 'x)
+		       (em-if (em-symbol? 'x)
 			      '((x e))
 			      '(((equal? x e)))))))
 


### PR DESCRIPTION
I am following most of John Cowan's suggestions here.

Also note that the title of this SRFI changed from "Composable macro" to "Eager syntax-rules" to follow the new terminology.